### PR TITLE
Close curly braces when the same conditions are met that opened them

### DIFF
--- a/example/test/ex46_json_test.g.dart
+++ b/example/test/ex46_json_test.g.dart
@@ -1,0 +1,15 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ex46_json_test.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Pet _$PetFromJson(Map<String, dynamic> json) => Pet(
+      kind: json['kind'] as String,
+    );
+
+Map<String, dynamic> _$PetToJson(Pet instance) => <String, dynamic>{
+      'kind': instance.kind,
+    };

--- a/example/test/ex59_json_test.g.dart
+++ b/example/test/ex59_json_test.g.dart
@@ -1,0 +1,49 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ex59_json_test.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Person _$PersonFromJson(Map<String, dynamic> json) => Person(
+      age: json['age'] as int,
+    );
+
+Map<String, dynamic> _$PersonToJson(Person instance) => <String, dynamic>{
+      'age': instance.age,
+    };
+
+Athlete _$AthleteFromJson(Map<String, dynamic> json) => Athlete(
+      speed: json['speed'] as int,
+      age: json['age'] as int,
+    );
+
+Map<String, dynamic> _$AthleteToJson(Athlete instance) => <String, dynamic>{
+      'speed': instance.speed,
+      'age': instance.age,
+    };
+
+BaseballPlayer _$BaseballPlayerFromJson(Map<String, dynamic> json) =>
+    BaseballPlayer(
+      speed: json['speed'] as int,
+      height: json['height'] as int,
+      age: json['age'] as int,
+    );
+
+Map<String, dynamic> _$BaseballPlayerToJson(BaseballPlayer instance) =>
+    <String, dynamic>{
+      'speed': instance.speed,
+      'height': instance.height,
+      'age': instance.age,
+    };
+
+Building _$BuildingFromJson(Map<String, dynamic> json) => Building(
+      people: (json['people'] as List<dynamic>)
+          .map((e) => Person.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$BuildingToJson(Building instance) => <String, dynamic>{
+      'people': instance.people.map((e) => e.toJson()).toList(),
+    };

--- a/example/test/ex63_empty_super_class_test.dart
+++ b/example/test/ex63_empty_super_class_test.dart
@@ -1,0 +1,20 @@
+import 'package:morphy_annotation/morphy_annotation.dart';
+import 'package:test/test.dart';
+
+part 'ex63_empty_super_class_test.morphy.dart';
+
+@Morphy(
+  explicitSubTypes: [
+    $AgreedEulaState,
+  ]
+)
+abstract class $EulaState
+{
+ // lack of members should not be a problem
+}
+
+@Morphy()
+abstract class $AgreedEulaState implements $EulaState
+{
+  bool get test;
+}

--- a/morphy/lib/src/helpers.dart
+++ b/morphy/lib/src/helpers.dart
@@ -315,7 +315,7 @@ String getCopyWith({
     return "${getDataTypeWithoutDollars(interfaceType!)} Function()? $name,\n";
   }).join());
 
-  if (fieldsForSignature.isNotEmpty) //
+  if (fieldsForSignature.isNotEmpty || requiredFields.isNotEmpty)
     sb.write("}");
 
   if (isClassAbstract && !isExplicitSubType) {


### PR DESCRIPTION
Fixes #21.
Found that  different conditions were used to determine when curly braces should be closed vs opening, causing a failure to close named parameter set in the scenario where by the super Morphy class has no members.
Tests included.