### PR TITLE
Following Dart naming Conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 
 *.morphy.dart
 *.morphy2.dart
+*.g.dart
 
 # Flutter/Dart/Pub related
 **/doc/api/

--- a/example/test/ex63_property_shadow_global_type.dart
+++ b/example/test/ex63_property_shadow_global_type.dart
@@ -1,0 +1,56 @@
+import 'package:morphy_annotation/morphy_annotation.dart';
+import 'package:test/test.dart';
+
+part 'ex63_property_shadow_global_type.morphy.dart';
+part 'ex63_property_shadow_global_type.g.dart';
+
+//nullable private getters and private morphy class
+
+main() {
+  test("1", () {
+    final test = Test(
+      String: 1,
+      Object: 2,
+      List: 3,
+      Map: 4,
+      Never: (5, 6),
+      Type: (7, named: 8),
+      bool: [2, 'abc'],
+      hashObjects: [4, 5],
+      identical: [6, 7],
+    );
+    expect(test.String, 1);
+    expect(test.bool, [2, 'abc']);
+    expect(Test.fromJson(test.toJson()).toJson(), test.toJson());
+
+    final test2 = Test2(
+      PositionalFunction: (a, [b = 3, c = 5]) => a + b + c
+    );
+    final f = test2.PositionalFunction;
+    expect(f(5, 5), 15);
+  });
+}
+
+typedef Int = int;
+typedef _List<E> = List<E>;
+typedef IntList = List<int>;
+
+@Morphy(generateJson: true)
+abstract class $Test {
+  Int get String;
+  Int get Object;
+  Int get List;
+  Int get Map;
+  (Int, Int)? get Never;
+  (Int, {Int named}) get Type;
+  _List<(Int, Int)>? get int;
+  _List get bool;
+  IntList get hashObjects;
+  _List<Int> get identical;
+}
+
+@Morphy(generateJson: false)
+abstract class $Test2 {
+  Int Function(Int p1, {Int n1, required Int n2})? get Function;
+  Int Function(Int p1, [Int p2, Int p3]) get PositionalFunction;
+}

--- a/morphy/CHANGELOG.md
+++ b/morphy/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 1.4.0
 - BREAKING CHANGE! copyWith_A is now copyWithA and changeTo_A is now changeToA
 - This is to make the naming more consistent with dart conventions
-- The overriden properties and methods did not have the 'override' annotation, this has been added
+- merged the PRs that allow to set explicitToJson false
+- Call the class fromJson if _className_ isn't specified
+- Support property name shadowing global types such as Type, String, In…
+- thanks to @miklcct for the PRs.
 
 ## 1.3.0
 - bug fixes, subclass with no members now works, generic copy with bug now fixed where type is incorrect

--- a/morphy/CHANGELOG.md
+++ b/morphy/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 1.4.0
-- BREAKING CHANGE! copyWith_A is now copyWithA and changeTo_A is now changeToA
+## 2.0.0
+- BREAKING CHANGES! copyWith_A is now copyWithA and changeTo_A is now changeToA
 - This is to make the naming more consistent with dart conventions
 - merged the PRs that allow to set explicitToJson false
 - Call the class fromJson if _className_ isn't specified

--- a/morphy/CHANGELOG.md
+++ b/morphy/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.0
+- BREAKING CHANGE! copyWith_A is now copyWithA and changeTo_A is now changeToA
+- This is to make the naming more consistent with dart conventions
+- The overriden properties and methods did not have the 'override' annotation, this has been added
+
 ## 1.3.0
 - bug fixes, subclass with no members now works, generic copy with bug now fixed where type is incorrect
 - in order to fix the above problem the type returned from the copywith is now the type of the named copywith function, eg b.copyWith_A now returns an A type
@@ -9,7 +14,7 @@
 - New functionality - private getters are now allowed!
 
 ## 1.1.0
-- Breaking change! copywith / change to, the Opt class has been removed and now we favour the () => syntax for optional parameters 
+- Breaking change! copywith / change to, the Opt class has been removed and now we favour the () => syntax for optional parameters
 
 ## 1.0.8
 - change_to added for a subclass to change the type back to a superclass

--- a/morphy/README.md
+++ b/morphy/README.md
@@ -7,8 +7,8 @@ We need a way to simplify our Dart classes, support polymorphism and allow copyi
 
 ### Why Not Freezed or Built Value?
 Well the main reason; I actually wrote this before Freezed was released.
-Freezed is really good, established and well used.  
-However if you want to use both inheritance and polymorphism use Morphy. 
+Freezed is really good, established and well used.
+However if you want to use both inheritance and polymorphism use Morphy.
 
 ### Solution: use morphy
 
@@ -24,7 +24,7 @@ To create a new class.
    ```
     import 'package:morphy_annotation/morphy_annotation.dart';
     part 'Pet.morphy.dart';
-    
+
     @morphy
     abstract class $Pet {
       String get type;
@@ -77,13 +77,13 @@ var cat1 = Pet(type: "cat");
 
 ### CopyWith
 
-A simple copy with implementation comes with every class.  
-We pass a function to the copyWith_Pet method that returns a new value to set the property.
+A simple copy with implementation comes with every class.
+We pass a function to the copyWithPet method that returns a new value to set the property.
 You can pass any value you like, including null if the property is nullable.
 
 ```
     var flossy = Pet(name: "Flossy", age: 5);
-    var plossy = flossy.copyWith_Pet(name: () => "Plossy");
+    var plossy = flossy.copyWithPet(name: () => "Plossy");
 
     expect(flossy.age, plossy.age);
 ```
@@ -107,9 +107,9 @@ All properties will be inherited by default.
     abstract class $Cat implements $Pet {
       int get whiskerLength;
     }
-    
+
     var bagpussCat = Cat(whiskerLength: 13.75, name: "Bagpuss", age: 4);
-    
+
     expect(bagpussCat.whiskerLength, 13.75);
 
 ### CopyWith Polymorphic
@@ -122,14 +122,14 @@ then the copyWith still works whilst preserving the underlying type.
       Cat(whiskerLength: 13.75, name: "Bagpuss", age: 4),
       Dog(woofSound: "rowf", name: "Colin", age: 4),
     ];
-    
+
     var petsOlder = pets //
-        .map((e) => e.copyWith_Pet(age: () => e.age + 1))
+        .map((e) => e.copyWithPet(age: () => e.age + 1))
         .toList();
-    
+
     expect(petsOlder[0].age, 5);
     expect(petsOlder[1].age, 5);
- 
+
 Importantly the type remains the same, it is not converted to a Pet class.
 
     expect(petsOlder[0].runtimeType, Cat);
@@ -147,7 +147,7 @@ Importantly the type remains the same, it is not converted to a Pet class.
 
 ### Generics are allowed
 
-Specify the class definition if you want to constrain your generic type (use the dollar) 
+Specify the class definition if you want to constrain your generic type (use the dollar)
 
     @morphy
     abstract class $PetOwner<TPet extends $Pet> {
@@ -157,7 +157,7 @@ Specify the class definition if you want to constrain your generic type (use the
 
     var cathy = PetOwner<Cat>(ownerName: "Cathy", pet: bagpussCat);
     var dougie = PetOwner<Dog>(ownerName: "Dougie", pet: colin);
-    
+
     expect(cathy.pet.whiskerLength, 13.75);
     expect(dougie.pet.woofSound, "rowf");
 
@@ -167,7 +167,7 @@ Sometimes you might want to turn a super class into a subclass (Pet into a Cat)
 
     var flossy = Pet(name: "Flossy", age: 5);
 
-    var bagpussCat = flossy.changeTo_Cat(whiskerLength: 13.75);
+    var bagpussCat = flossy.changeToCat(whiskerLength: 13.75);
 
     expect(bagpussCat.whiskerLength, 13.75);
     expect(bagpussCat.runtimeType, Cat);
@@ -176,13 +176,13 @@ Sometimes you might want to turn a super class into a subclass (Pet into a Cat)
 
 ### Convert object to Json
 
-In order to convert the object to Json specify the `generateJson`. 
+In order to convert the object to Json specify the `generateJson`.
 
     @Morphy(generateJson: true)
     abstract class $Pet {
 
 Add the dev dependency to the json_serializable package
-    
+
     dart pub add json_serializable --dev
 
 Add the part file, .g is required by the json_serializable package used internally by `morphy`
@@ -209,19 +209,19 @@ Use the factory method `Pet.fromJson()` to create the new object.
 ### Json to Object Polymorphism
 
 Unlike other json conversions you can convert subtypes using the super types toJson and fromJson functions.
-   
+
 The subtypes must be specified in the explicitSubTypes and in the correct order for this to work.
 
     @Morphy(generateJson: true, explicitSubTypes: [$Z, $Y])
     abstract class $X {
       String get val;
     }
-    
+
     @Morphy(generateJson: true, explicitSubTypes: [$Z])
     abstract class $Y implements $X {
       int get valY;
     }
-    
+
     @Morphy(generateJson: true)
     abstract class $Z implements $Y {
       double get valZ;
@@ -267,10 +267,10 @@ We also allow multiple inheritance.
 
 ### Custom Constructors
 
-To allow custom constructors you can simply create a publicly accessible factory function that calls the constructor (ie just a method that calls the default constructor). 
+To allow custom constructors you can simply create a publicly accessible factory function that calls the constructor (ie just a method that calls the default constructor).
 If you'd like to hide the automatic constructor set the `hidePublicConstructor` on the Morphy annotation to true.
-If you do hide the default constructor, 
-then in order for the custom factory function (A_FactoryFunction in the example below) to be able to call the hidden (or private) default constructor, 
+If you do hide the default constructor,
+then in order for the custom factory function (A_FactoryFunction in the example below) to be able to call the hidden (or private) default constructor,
 your factory function should live in the same file you defined your class.
 
     @Morphy(hidePublicConstructor: true)
@@ -304,7 +304,7 @@ Optional parameters can be specified using the ? keyword on the getter property.
 ### Comments
 
 Comments are copied from the class definition to the generated class
-and for ease of use copied to the constructor too. 
+and for ease of use copied to the constructor too.
 
 ### Constant Constructor
 
@@ -313,7 +313,7 @@ Just define a blank const constructor in your class definition file
     const $A();
 
 Then call the const constructor using the named constructor ```constant``
-        
+
     var a = A.constant();
 
 ### Private Getters
@@ -324,17 +324,17 @@ If we start our property with an underscore then we make the getter private but 
       @morphy
       abstract class $$Pet {
          int get _ageInYears;
-         
+
          String get name;
       }
-      
+
       @morphy
       abstract class $Cat implements $$Pet {}
-      
-      @morphy
-      abstract class $Dog implements $$Pet {}      
 
-      extension Pet_E on Pet {
+      @morphy
+      abstract class $Dog implements $$Pet {}
+
+      extension PetE on Pet {
          int age() => switch (this) {
             Cat() => _ageInYears * 7,
             Dog() => _ageInYears * 5,
@@ -343,7 +343,7 @@ If we start our property with an underscore then we make the getter private but 
 
        var cat = Cat(name: "Tom", ageInYears: 3);
        var dog = Dog(name: "Rex", ageInYears: 3);
-   
+
        expect(cat.age(), 21);
        expect(dog.age(), 15);
 
@@ -358,4 +358,4 @@ a kind of two step route back.  You must go to the generated and then you can cl
 $ version of the class which will be next to it.
 
 Sometimes one class needs to be built before another.
-In that scenario use morphy2 as the annotation in one class and morphy in the other.  
+In that scenario use morphy2 as the annotation in one class and morphy in the other.

--- a/morphy/README.md
+++ b/morphy/README.md
@@ -190,9 +190,9 @@ Add the part file, .g is required by the json_serializable package used internal
     part 'Pets.g.dart';
     part 'Pets.morphy.dart';
 
-Build the generated files then use the toJson_2 method to generate the JSON
+Build the generated files then use the toJsonCustom method to generate the JSON
 
-    var json = flossy.toJson_2({});
+    var json = flossy.toJsonCustom({});
     expect(json, {'name': 'Flossy', 'age': 5, '_className_': 'Pet'});
 
 ### Convert Json to Object
@@ -235,7 +235,7 @@ The subtypes must be specified in the explicitSubTypes and in the correct order 
 
 We can then just convert our list of X objects to JSON preserving their original type.
 
-    var resultInJsonFormat = xObjects.map((e) => e.toJson_2({})).toList();
+    var resultInJsonFormat = xObjects.map((e) => e.toJsonCustom({})).toList();
 
     var expectedJson = [
       {'val': 'x', '_className_': 'X'},

--- a/morphy/lib/morphy2Builder.dart
+++ b/morphy/lib/morphy2Builder.dart
@@ -7,5 +7,5 @@ Builder morphy2Builder(BuilderOptions options) => //
     PartBuilder([MorphyGenerator<Morphy2>()], '.morphy2.dart',
         header: '''
 // ignore_for_file: UNNECESSARY_CAST
-// ignore_for_file: unused_element
+// ignore_for_file: type=lint
     ''');

--- a/morphy/lib/morphyBuilder.dart
+++ b/morphy/lib/morphyBuilder.dart
@@ -7,5 +7,5 @@ Builder morphyBuilder(BuilderOptions options) => //
     PartBuilder([MorphyGenerator<Morphy>()], '.morphy.dart',
         header: '''
 // ignore_for_file: UNNECESSARY_CAST
-// ignore_for_file: unused_element
+// ignore_for_file: type=lint
     ''');

--- a/morphy/lib/src/MorphyGenerator.dart
+++ b/morphy/lib/src/MorphyGenerator.dart
@@ -60,9 +60,9 @@ class MorphyGenerator<TValueT extends MorphyX> extends GeneratorForAnnotationX<T
         .map((e) => //
             InterfaceWithComment(
               e.element.name,
-              e.typeArguments.map((e) => e.toString()).toList(),
+              e.typeArguments.map(typeToString).toList(),
               e.element.typeParameters.map((x) => x.name).toList(),
-              e.element.fields.map((e) => NameType(e.name, e.type.toString())).toList(),
+              e.element.fields.map((e) => NameType(e.name, typeToString(e.type))).toList(),
               comment: e.element.documentationComment,
             )) //
         .toList();
@@ -72,7 +72,10 @@ class MorphyGenerator<TValueT extends MorphyX> extends GeneratorForAnnotationX<T
 //    });
 
     var classGenerics = ce.typeParameters
-        .map((e) => NameTypeClassComment(e.name, e.bound == null ? null : e.bound.toString(), null)) //
+        .map((e) {
+          final bound = e.bound;
+          return NameTypeClassComment(e.name, bound == null ? null : typeToString(bound), null);
+        }) //
         .toList();
 
     var allFieldsDistinct = getDistinctFields(allFields, interfaces);
@@ -93,8 +96,10 @@ class MorphyGenerator<TValueT extends MorphyX> extends GeneratorForAnnotationX<T
         return Interface.fromGenerics(
           el.name,
           el.typeParameters //
-              .map((TypeParameterElement x) => //
-                  NameType(x.name, x.bound == null ? null : x.bound.toString()))
+              .map((TypeParameterElement x) {
+                final bound = x.bound;
+                return NameType(x.name, bound == null ? null : typeToString(bound));
+              })
               .toList(),
           getAllFields(el.allSupertypes, el).where((x) => x.name != "hashCode").toList(),
           true,
@@ -110,8 +115,10 @@ class MorphyGenerator<TValueT extends MorphyX> extends GeneratorForAnnotationX<T
             return Interface.fromGenerics(
               e.element.name,
               e.element.typeParameters //
-                  .map((TypeParameterElement x) => //
-                      NameType(x.name, x.bound == null ? null : x.bound.toString()))
+                  .map((TypeParameterElement x) {
+                    final bound = x.bound;
+                    return NameType(x.name, bound == null ? null : typeToString(bound));
+                  })
                   .toList(),
               getAllFields(e.element.allSupertypes, e.element as ClassElement).where((x) => x.name != "hashCode").toList(),
             );
@@ -134,6 +141,7 @@ class MorphyGenerator<TValueT extends MorphyX> extends GeneratorForAnnotationX<T
       annotation.read('hidePublicConstructor').boolValue,
       typesExplicit,
       annotation.read('nonSealed').boolValue,
+      annotation.read('explicitToJson').boolValue,
     ));
 
 //    sb.writeln(createCopyWith(classDef, otherClasses2).replaceAll("\$", ""));

--- a/morphy/lib/src/common/GeneratorForAnnotationX.dart
+++ b/morphy/lib/src/common/GeneratorForAnnotationX.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'package:analyzer/dart/element/element.dart';
 // ignore: import_of_legacy_library_into_null_safe
 import 'package:build/build.dart';
+import 'package:morphy/src/MorphyGenerator.dart';
+import 'package:morphy_annotation/morphy_annotation.dart';
 // ignore: import_of_legacy_library_into_null_safe
 import 'package:source_gen/source_gen.dart';
 // ignore: import_of_legacy_library_into_null_safe
@@ -40,6 +42,21 @@ abstract class GeneratorForAnnotationX<T> extends Generator {
 
   @override
   FutureOr<String> generate(LibraryReader library, BuildStep buildStep) async {
+    const typedefs =
+      """   
+typedef __String = String;
+typedef __Object = Object;
+// ignore: unused_element
+typedef __List<E> = List<E>;
+typedef __Map<K, V> = Map<K, V>;
+typedef __Never = Never;
+typedef __Type = Type;
+typedef __int = int;
+typedef __bool = bool;
+const __hashObjects = hashObjects;
+const __identical = identical;
+"""
+    ;
     final values = Set<String>();
 
     var classElements = library.allElements //
@@ -59,7 +76,10 @@ abstract class GeneratorForAnnotationX<T> extends Generator {
       }
     }
 
-    return values.join('\n\n');
+    return [
+      if (this is MorphyGenerator<Morphy> && values.isNotEmpty) typedefs,
+      ...values
+    ].join('\n\n');
   }
 
   /// Implement to return source code to generate for [element].

--- a/morphy/lib/src/common/helpers.dart
+++ b/morphy/lib/src/common/helpers.dart
@@ -1,5 +1,5 @@
-// ignore: import_of_legacy_library_into_null_safe
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:dartx/dartx.dart';
 
@@ -28,7 +28,7 @@ MethodDetails<TMeta1> getMethodDetailsForFunctionType<TMeta1>(
   FunctionTypedElement fn,
   TMeta1 GetMetaData(ParameterElement parameterElement),
 ) {
-  var returnType = fn.returnType.toString();
+  var returnType = typeToString(fn.returnType);
 
   var paramsPositional2 = fn.parameters.where((x) => x.isPositional);
   var paramsNamed2 = fn.parameters.where((x) => x.isNamed);
@@ -36,7 +36,7 @@ MethodDetails<TMeta1> getMethodDetailsForFunctionType<TMeta1>(
   var paramsPositional = paramsPositional2
       .map((x) => NameTypeClassCommentData<TMeta1>(
             x.name.toString(),
-            x.type.toString(),
+            typeToString(x.type),
             null,
             comment: x.documentationComment,
             meta1: GetMetaData(x),
@@ -45,7 +45,7 @@ MethodDetails<TMeta1> getMethodDetailsForFunctionType<TMeta1>(
   var paramsNamed = paramsNamed2
       .map((x) => NameTypeClassCommentData<TMeta1>(
             x.name.toString(),
-            x.type.toString(),
+            typeToString(x.type),
             null,
             comment: x.documentationComment,
             meta1: GetMetaData(x),
@@ -53,7 +53,10 @@ MethodDetails<TMeta1> getMethodDetailsForFunctionType<TMeta1>(
       .toList();
 
   var typeParameters2 = fn.typeParameters //
-      .map((e) => GenericsNameType(e.name, e.bound == null ? null : e.bound.toString()))
+      .map((e) {
+        final bound = e.bound;
+        return GenericsNameType(e.name, bound == null ? null : typeToString(bound));
+      })
       .toList();
 
   return MethodDetails<TMeta1>(fn.documentationComment, fn.name ?? "", paramsPositional, paramsNamed, typeParameters2, returnType);
@@ -63,7 +66,7 @@ List<NameTypeClassComment> getAllFields(List<InterfaceType> interfaceTypes, Clas
   var superTypeFields = interfaceTypes //
       .where((x) => x.element.name != "Object")
       .flatMap((st) => st.element.fields.map((f) => //
-          NameTypeClassComment(f.name, f.type.toString(), st.element.name, comment: f.getter?.documentationComment)))
+          NameTypeClassComment(f.name, typeToString(f.type), st.element.name, comment: f.getter?.documentationComment)))
       .toList();
 
 //  if(element is ClassElement){
@@ -75,8 +78,60 @@ List<NameTypeClassComment> getAllFields(List<InterfaceType> interfaceTypes, Clas
 //  }
 
   var classFields = element.fields.map((f) => //
-      NameTypeClassComment(f.name, f.type.toString(), element.name, comment: f.getter?.documentationComment)).toList();
+      NameTypeClassComment(f.name, typeToString(f.type), element.name, comment: f.getter?.documentationComment)).toList();
 
   //distinct, will keep classFields over superTypeFields
   return (classFields + superTypeFields).distinctBy((x) => x.name).toList();
+}
+
+String typeToString(DartType type) {
+  final alias = type.alias;
+  final manual = alias != null
+    ? aliasToString(alias)
+    : type is FunctionType
+      ? functionToString(type)
+      : type is RecordType
+        ? recordToString(type)
+        : type is ParameterizedType
+          ? genericToString(type)
+          : null;
+  final nullMarker = type.nullabilitySuffix == NullabilitySuffix.question ? '?'
+    : type.nullabilitySuffix == NullabilitySuffix.star ? '*'
+    : '';
+  return manual != null ? "$manual$nullMarker" : type.toString();
+}
+
+String aliasToString(InstantiatedTypeAliasElement alias) => "${alias.element.name}${alias.typeArguments.isEmpty ? '' : "<${alias.typeArguments.map(typeToString).join(', ')}>"}";
+
+String functionToString(FunctionType type) {
+  final generics = type.typeFormals.isNotEmpty ? "<${
+    type.typeFormals
+      .map((param) {
+        final bound = param.bound;
+        return "${param.name}${bound == null ? "" : " = ${typeToString(bound)}"}";
+      })
+      .join(', ')
+  }>" : '';
+  final normal = type.normalParameterNames.mapIndexed(
+    (index, name) => "${typeToString(type.normalParameterTypes[index])} $name"
+  ).join(', ');
+  final named = type.namedParameterTypes.mapEntries((entry) => "${entry.value.element!.hasRequired ? 'required ' : ''}${typeToString(entry.value)} ${entry.key}").join(', ');
+  final optional = type.optionalParameterNames.mapIndexed(
+    (index, name) => "${typeToString(type.optionalParameterTypes[index])} $name"
+  ).join(', ');
+  return "${typeToString(type.returnType)} Function$generics(${
+    [if (normal.isNotEmpty) normal, if (named.isNotEmpty) "{$named}", if (optional.isNotEmpty) "[$optional]"].join(', ')
+  })";
+}
+
+String recordToString(RecordType type) {
+  final positional = type.positionalFields.map((e) => typeToString(e.type)).join(', ');
+  final named = type.namedFields.map((e) => "${typeToString(e.type)} ${e.name}").join(', ');
+  final trailing = type.positionalFields.length == 1 && type.namedFields.length == 0 ? ',' : '';
+  return "(${[if (positional.isNotEmpty) positional, if (named.isNotEmpty) "{$named}"].join(', ')}$trailing)";
+}
+
+String genericToString(ParameterizedType type) {
+  final arguments = type.typeArguments.isEmpty ? '' : "<${type.typeArguments.map(typeToString).join(', ')}>";
+  return "${type.element!.name}$arguments";
 }

--- a/morphy/lib/src/createMorphy.dart
+++ b/morphy/lib/src/createMorphy.dart
@@ -15,6 +15,7 @@ String createMorphy(
   bool hidePublicConstructor,
   List<Interface> explicitForJson,
   bool nonSealed,
+  bool explicitToJson,
 ) {
   //recursively go through otherClasses and get my fieldnames &
 
@@ -26,8 +27,8 @@ String createMorphy(
   //move this into a helper class!
   if (generateJson) {
     sb.writeln(createJsonSingleton(classNameTrim, classGenerics));
-    sb.writeln(
-        createJsonHeader(className, classGenerics, hidePublicConstructor));
+    sb.writeln(createJsonHeader(className, classGenerics, hidePublicConstructor, explicitToJson));
+
   }
 
   sb.write(getClassDefinition(

--- a/morphy/lib/src/createMorphy.dart
+++ b/morphy/lib/src/createMorphy.dart
@@ -26,10 +26,12 @@ String createMorphy(
   //move this into a helper class!
   if (generateJson) {
     sb.writeln(createJsonSingleton(classNameTrim, classGenerics));
-    sb.writeln(createJsonHeader(className, classGenerics, hidePublicConstructor));
+    sb.writeln(
+        createJsonHeader(className, classGenerics, hidePublicConstructor));
   }
 
-  sb.write(getClassDefinition(isAbstract: isAbstract, nonSealed: nonSealed, className: className));
+  sb.write(getClassDefinition(
+      isAbstract: isAbstract, nonSealed: nonSealed, className: className));
 
   if (classGenerics.isNotEmpty) {
     sb.write(getClassGenerics(classGenerics));
@@ -62,25 +64,25 @@ String createMorphy(
       if (!hidePublicConstructor) {
         sb.writeln("${classNameTrim}({");
         sb.writeln(getConstructorRows(allFields));
-        sb.writeln("}) ${getInitialiser(allFields)};");
+        sb.writeln("}) ${getInitializer(allFields)};");
       }
 
       //the json needs a public constructor, we add this if public constructor is hidden
       if (hidePublicConstructor && generateJson) {
         sb.writeln("${classNameTrim}.forJsonDoNotUse({");
         sb.writeln(getConstructorRows(allFields));
-        sb.writeln("}) ${getInitialiser(allFields)};");
+        sb.writeln("}) ${getInitializer(allFields)};");
       }
 
       //we always want to write a private constructor (just a duplicate)
       sb.writeln("${classNameTrim}._({");
       sb.writeln(getConstructorRows(allFields));
-      sb.writeln("}) ${getInitialiser(allFields)};");
+      sb.writeln("}) ${getInitializer(allFields)};");
 
       if (hasConstContructor) {
         sb.writeln("const ${classNameTrim}.constant({");
         sb.writeln(getConstructorRows(allFields));
-        sb.writeln("}) ${getInitialiser(allFields)};");
+        sb.writeln("}) ${getInitializer(allFields)};");
       }
       sb.writeln(getToString(allFields, classNameTrim));
     }
@@ -126,9 +128,9 @@ String createMorphy(
   sb.writeln("}");
 
   sb.writeln();
-  sb.writeln("extension ${className}_changeTo_E on ${className} {");
+  sb.writeln("extension ${className}changeToE on ${className} {");
 
-  if(!isAbstract){
+  if (!isAbstract) {
     sb.writeln(
       getCopyWith(
         classFields: allFields,

--- a/morphy/lib/src/helpers.dart
+++ b/morphy/lib/src/helpers.dart
@@ -209,7 +209,9 @@ String getToString(List<NameType> fields, String className) {
     return """__String toString() => "($className-)""";
   }
 
-  var items = fields.map((e) => "${e.name}:\${${e.name}.toString()}").joinToString(separator: "|");
+  var items = fields
+      .map((e) => "${e.name}:\${${e.name}.toString()}")
+      .joinToString(separator: "|");
   return """__String toString() => "($className-$items)";""";
 }
 
@@ -218,15 +220,16 @@ String getHashCode(List<NameType> fields) {
     return "";
   }
 
-  var items = fields.map((e) => "${e.name}.hashCode").joinToString(separator: ", ");
+  var items =
+      fields.map((e) => "${e.name}.hashCode").joinToString(separator: ", ");
   return """__int get hashCode => __hashObjects([$items]);""";
 }
 
 String getEquals(List<NameType> fields, String className) {
   var sb = StringBuffer();
 
-  sb.write("__bool operator ==(__Object other) => __identical(this, other) || other is $className && runtimeType == other.runtimeType");
-
+  sb.write(
+      "__bool operator ==(__Object other) => __identical(this, other) || other is $className && runtimeType == other.runtimeType");
 
   sb.writeln(fields.isEmpty ? "" : " &&");
 
@@ -249,7 +252,8 @@ String getEquals(List<NameType> fields, String className) {
   return sb.toString();
 }
 
-String createJsonHeader(String className, List<NameType> classGenerics, bool privateConstructor, bool explicitToJson) {
+String createJsonHeader(String className, List<NameType> classGenerics,
+    bool privateConstructor, bool explicitToJson) {
   var sb = StringBuffer();
 
   if (!className.startsWith("\$\$")) {
@@ -257,9 +261,11 @@ String createJsonHeader(String className, List<NameType> classGenerics, bool pri
         privateConstructor ? "constructor: 'forJsonDoNotUse'" : "";
 
     if (classGenerics.length > 0) //
-      sb.writeln("@JsonSerializable(explicitToJson: $explicitToJson, genericArgumentFactories: true, $jsonConstructorName)");
+      sb.writeln(
+          "@JsonSerializable(explicitToJson: $explicitToJson, genericArgumentFactories: true, $jsonConstructorName)");
     else
-      sb.writeln("@JsonSerializable(explicitToJson: $explicitToJson, $jsonConstructorName)");
+      sb.writeln(
+          "@JsonSerializable(explicitToJson: $explicitToJson, $jsonConstructorName)");
   }
 
   return sb.toString();
@@ -493,7 +499,7 @@ String generateFromJsonBody(
 
 String generateToJson(String className, List<NameType> generics) {
   if (className.startsWith("\$\$")) {
-    return "__Map<__String, dynamic> toJson_2([__Map<__Type, __Object? Function(__Never)>? fns]);";
+    return "__Map<__String, dynamic> toJsonCustom([__Map<__Type, __Object? Function(__Never)>? fns]);";
   }
 
   var _className = "${className.replaceFirst("\$", "")}";
@@ -514,7 +520,7 @@ String generateToJson(String className, List<NameType> generics) {
   // ignore: unused_field
   __Map<__Type, __Object? Function(__Never)> _fns = {};
 
-  __Map<__String, dynamic> toJson_2([__Map<__Type, __Object? Function(__Never)>? fns]){
+  __Map<__String, dynamic> toJsonCustom([__Map<__Type, __Object? Function(__Never)>? fns]){
     this._fns = fns ?? {};
     return toJson();
   }

--- a/morphy/lib/src/helpers.dart
+++ b/morphy/lib/src/helpers.dart
@@ -164,8 +164,7 @@ String getDataTypeWithoutDollars(String type) {
 
 String getProperties(List<NameTypeClassComment> fields) {
   return fields.map((e) {
-    var line =
-        "@override\nfinal ${getDataTypeWithoutDollars(e.type ?? "")} ${e.name};";
+    var line = "final ${getDataTypeWithoutDollars(e.type ?? "")} ${e.name};";
     var result = e.comment == null ? line : "${e.comment}\n$line";
     return result;
   }).join("\n");
@@ -489,7 +488,7 @@ String generateFromJsonBody(
   var _className = className.replaceFirst("\$", "").replaceFirst("\$", "");
 
   var end = """    } else {
-      return _\$${_className}FromJson(json, );
+      throw UnsupportedError("The _className_ '\${json['_className_']}' is not supported by the ${_className}.fromJson constructor.");
     }
   }
 """;
@@ -521,7 +520,7 @@ String generateToJson(String className, List<NameType> generics) {
   __Map<__Type, __Object? Function(__Never)> _fns = {};
 
   __Map<__String, dynamic> toJsonCustom([__Map<__Type, __Object? Function(__Never)>? fns]){
-    this._fns = fns ?? {};
+    _fns = fns ?? {};
     return toJson();
   }
 

--- a/morphy/lib/src/helpers.dart
+++ b/morphy/lib/src/helpers.dart
@@ -36,7 +36,9 @@ List<NameTypeClassComment> getDistinctFields(
   List<NameTypeClassComment> fieldsRaw,
   List<InterfaceWithComment> interfaces,
 ) {
-  var fields = fieldsRaw.map((f) => NameTypeClassComment(f.name, f.type, f.className?.replaceAll("\$", ""), comment: f.comment));
+  var fields = fieldsRaw.map((f) => NameTypeClassComment(
+      f.name, f.type, f.className?.replaceAll("\$", ""),
+      comment: f.comment));
 
   var interfaces2 = interfaces //
       .map((x) => Interface.fromGenerics(
@@ -49,11 +51,16 @@ List<NameTypeClassComment> getDistinctFields(
 //    return Interface2(interface.type.replaceAll("\$", ""), result);
 //  }).toList();
 
-  var sortedFields = fields.sortedBy((element) => element.className ?? "").toList();
-  var distinctFields = sortedFields.distinctBy((element) => element.name).toList();
+  var sortedFields =
+      fields.sortedBy((element) => element.className ?? "").toList();
+  var distinctFields =
+      sortedFields.distinctBy((element) => element.name).toList();
 
   var adjustedFields = distinctFields.map((classField) {
-    var i = interfaces2.where((x) => x.interfaceName == classField.className).take(1).toList();
+    var i = interfaces2
+        .where((x) => x.interfaceName == classField.className)
+        .take(1)
+        .toList();
     if (i.length > 0) {
       var paramNameType = i[0]
           .typeParams
@@ -62,18 +69,23 @@ List<NameTypeClassComment> getDistinctFields(
           .toList();
       if (paramNameType.length > 0) {
         var name = removeDollarsFromPropertyType(paramNameType[0].type!);
-        return NameTypeClassComment(classField.name, name, null, comment: classField.comment);
+        return NameTypeClassComment(classField.name, name, null,
+            comment: classField.comment);
       }
     }
 
     var type = removeDollarsFromPropertyType(classField.type!);
-    return NameTypeClassComment(classField.name, type, null, comment: classField.comment);
+    return NameTypeClassComment(classField.name, type, null,
+        comment: classField.comment);
   }).toList();
 
   return adjustedFields;
 }
 
-String getClassDefinition({required bool isAbstract, required bool nonSealed, required String className}) {
+String getClassDefinition(
+    {required bool isAbstract,
+    required bool nonSealed,
+    required String className}) {
   var _className = className.replaceAll("\$", "");
 
   var abstract = isAbstract ? (nonSealed ? "abstract " : "sealed ") : "";
@@ -127,7 +139,8 @@ String getImplements(List<Interface> interfaces, String className) {
   return " implements $types";
 }
 
-String getEnumPropertyList(List<NameTypeClassComment> fields, String className) {
+String getEnumPropertyList(
+    List<NameTypeClassComment> fields, String className) {
   if (fields.isEmpty) //
     return '';
 
@@ -151,7 +164,8 @@ String getDataTypeWithoutDollars(String type) {
 
 String getProperties(List<NameTypeClassComment> fields) {
   return fields.map((e) {
-    var line = "final ${getDataTypeWithoutDollars(e.type ?? "")} ${e.name};";
+    var line =
+        "@override\nfinal ${getDataTypeWithoutDollars(e.type ?? "")} ${e.name};";
     var result = e.comment == null ? line : "${e.comment}\n$line";
     return result;
   }).join("\n");
@@ -168,7 +182,8 @@ String getPropertiesAbstract(List<NameTypeClassComment> fields) => //
 String getConstructorRows(List<NameType> fields) => //
     fields
         .map((e) {
-          var required = e.type!.substring(e.type!.length - 1) == "?" ? "" : "required ";
+          var required =
+              e.type!.substring(e.type!.length - 1) == "?" ? "" : "required ";
           var thisOrType = e.name.startsWith("_") ? "${e.type} " : "this.";
           var propertyName = e.name[0] == '_' ? e.name.substring(1) : e.name;
           return "$required$thisOrType$propertyName,";
@@ -176,7 +191,7 @@ String getConstructorRows(List<NameType> fields) => //
         .join("\n")
         .trim();
 
-String getInitialiser(List<NameType> fields) {
+String getInitializer(List<NameType> fields) {
   var result = fields
       .where((e) => e.name.startsWith('_'))
       .map((e) {
@@ -191,11 +206,13 @@ String getInitialiser(List<NameType> fields) {
 
 String getToString(List<NameType> fields, String className) {
   if (fields.isEmpty) {
-    return """String toString() => "($className-)""";
+    return """@override\nString toString() => "($className-)""";
   }
 
-  var items = fields.map((e) => "${e.name}:\${${e.name}.toString()}").joinToString(separator: "|");
-  return """String toString() => "($className-$items)";""";
+  var items = fields
+      .map((e) => "${e.name}:\${${e.name}.toString()}")
+      .joinToString(separator: "|");
+  return """@override\nString toString() => "($className-$items)";""";
 }
 
 String getHashCode(List<NameType> fields) {
@@ -203,19 +220,22 @@ String getHashCode(List<NameType> fields) {
     return "";
   }
 
-  var items = fields.map((e) => "${e.name}.hashCode").joinToString(separator: ", ");
-  return """int get hashCode => hashObjects([$items]);""";
+  var items =
+      fields.map((e) => "${e.name}.hashCode").joinToString(separator: ", ");
+  return """@override\nint get hashCode => hashObjects([$items]);""";
 }
 
 String getEquals(List<NameType> fields, String className) {
   var sb = StringBuffer();
 
-  sb.write("bool operator ==(Object other) => identical(this, other) || other is $className && runtimeType == other.runtimeType");
+  sb.write(
+      "bool operator ==(Object other) => identical(this, other) || other is $className && runtimeType == other.runtimeType");
 
   sb.writeln(fields.isEmpty ? "" : " &&");
 
   sb.write(fields.map((e) {
-    if ((e.type!.characters.take(5).string == "List<" || e.type!.characters.take(4).string == "Set<")) {
+    if ((e.type!.characters.take(5).string == "List<" ||
+        e.type!.characters.take(4).string == "Set<")) {
       //todo: hack here, a nullable entry won't compare properly to an empty list
       if (e.type!.characters.last == "?") {
         return "(${e.name}??[]).equalUnorderedD(other.${e.name}??[])";
@@ -232,16 +252,20 @@ String getEquals(List<NameType> fields, String className) {
   return sb.toString();
 }
 
-String createJsonHeader(String className, List<NameType> classGenerics, bool privateConstructor) {
+String createJsonHeader(
+    String className, List<NameType> classGenerics, bool privateConstructor) {
   var sb = StringBuffer();
 
   if (!className.startsWith("\$\$")) {
-    var jsonConstructorName = privateConstructor ? "constructor: 'forJsonDoNotUse'" : "";
+    var jsonConstructorName =
+        privateConstructor ? "constructor: 'forJsonDoNotUse'" : "";
 
     if (classGenerics.length > 0) //
-      sb.writeln("@JsonSerializable(explicitToJson: true, genericArgumentFactories: true, $jsonConstructorName)");
+      sb.writeln(
+          "@JsonSerializable(explicitToJson: true, genericArgumentFactories: true, $jsonConstructorName)");
     else
-      sb.writeln("@JsonSerializable(explicitToJson: true, $jsonConstructorName)");
+      sb.writeln(
+          "@JsonSerializable(explicitToJson: true, $jsonConstructorName)");
   }
 
   return sb.toString();
@@ -258,7 +282,8 @@ String getCopyWith({
   required String className,
   required bool isClassAbstract,
   required List<NameType> interfaceGenerics,
-  bool isExplicitSubType = false, //for where we specify the explicit subtypes for changeTo
+  bool isExplicitSubType =
+      false, //for where we specify the explicit subtypes for changeTo
 }) {
   var sb = StringBuffer();
 
@@ -290,8 +315,10 @@ String getCopyWith({
   }
 
   isExplicitSubType //
-      ? sb.write("$interfaceNameTrimmed$interfaceGenericStringNoExtends changeTo_$interfaceNameTrimmed$interfaceGenericStringWithExtends")
-      : sb.write("$interfaceNameTrimmed$interfaceGenericStringNoExtends copyWith_$interfaceNameTrimmed$interfaceGenericStringWithExtends");
+      ? sb.write(
+          "$interfaceNameTrimmed$interfaceGenericStringNoExtends changeTo$interfaceNameTrimmed$interfaceGenericStringWithExtends")
+      : sb.write(
+          "$interfaceNameTrimmed$interfaceGenericStringNoExtends copyWith$interfaceNameTrimmed$interfaceGenericStringWithExtends");
 
   // if (interfaceGenerics.isNotEmpty) {
   //   var generic = interfaceGenerics //
@@ -308,7 +335,8 @@ String getCopyWith({
   //use the type of the class
 
   var fieldsForSignature = classFields //
-      .where((element) => interfaceFields.map((e) => e.name).contains(element.name));
+      .where((element) =>
+          interfaceFields.map((e) => e.name).contains(element.name));
 
   // identify fields in the interface not in the class
   var requiredFields = isExplicitSubType //
@@ -323,7 +351,8 @@ String getCopyWith({
   sb.writeln();
 
   sb.write(requiredFields.map((e) {
-    var interfaceType = interfaceFields.firstWhere((element) => element.name == e.name).type;
+    var interfaceType =
+        interfaceFields.firstWhere((element) => element.name == e.name).type;
     return "required ${getDataTypeWithoutDollars(interfaceType!)} ${e.name},\n";
   }).join());
 
@@ -339,7 +368,7 @@ String getCopyWith({
     return "${getDataTypeWithoutDollars(interfaceType!)} Function()? $name,\n";
   }).join());
 
-  if (fieldsForSignature.isNotEmpty|| requiredFields.isNotEmpty) //
+  if (fieldsForSignature.isNotEmpty || requiredFields.isNotEmpty) //
     sb.write("}");
 
   if (isClassAbstract && !isExplicitSubType) {
@@ -366,15 +395,18 @@ String getCopyWith({
       .map((e) {
     var name = e.name.startsWith("_") ? e.name.substring(1) : e.name;
 
-    var classType = getDataTypeWithoutDollars(classFields.firstWhere((element) => element.name == e.name).type!);
+    var classType = getDataTypeWithoutDollars(
+        classFields.firstWhere((element) => element.name == e.name).type!);
     return "$name: $name == null ? this.${e.name} as $classType : $name() as $classType,\n";
   }).join());
 
   var fieldsNotInSignature = classFields //
-      .where((element) => !interfaceFields.map((e) => e.name).contains(element.name));
+      .where((element) =>
+          !interfaceFields.map((e) => e.name).contains(element.name));
 
   sb.write(fieldsNotInSignature //
-      .map((e) => "${e.name.startsWith('_') ? e.name.substring(1) : e.name}: (this as $classNameTrimmed).${e.name},\n")
+      .map((e) =>
+          "${e.name.startsWith('_') ? e.name.substring(1) : e.name}: (this as $classNameTrimmed).${e.name},\n")
       .join());
 
   sb.write(") as $interfaceNameTrimmed$interfaceGenericStringNoExtends;");
@@ -424,8 +456,10 @@ String generateFromJsonHeader(String className) {
   return "factory ${_className.replaceFirst("\$", "")}.fromJson(Map<String, dynamic> json) {";
 }
 
-String generateFromJsonBody(String className, List<NameType> generics, List<Interface> interfaces) {
-  var _class = Interface(className, generics.map((e) => e.type ?? "").toList(), generics.map((e) => e.name).toList(), []);
+String generateFromJsonBody(
+    String className, List<NameType> generics, List<Interface> interfaces) {
+  var _class = Interface(className, generics.map((e) => e.type ?? "").toList(),
+      generics.map((e) => e.name).toList(), []);
   var _classes = [...interfaces, _class];
 
   var body = _classes //
@@ -442,12 +476,12 @@ String generateFromJsonBody(String className, List<NameType> generics, List<Inte
         ${_interfaceName}_Generics_Sing().fns,
         json,
         [$genericTypes],
-      );    
+      );
       return fn_fromJson(json);
 """;
     } else {
       return """$start (json['_className_'] == "$_interfaceName") {
-    return _\$${_interfaceName}FromJson(json, ); 
+    return _\$${_interfaceName}FromJson(json, );
 """;
     }
   }).join("\n");
@@ -519,7 +553,7 @@ class ${classNameTrim}_Generics_Sing {
   static final ${classNameTrim}_Generics_Sing _singleton = ${classNameTrim}_Generics_Sing._internal();
 
   ${classNameTrim}_Generics_Sing._internal() {}
-}    
+}
     """;
 
   return result;

--- a/morphy/lib/src/helpers.dart
+++ b/morphy/lib/src/helpers.dart
@@ -229,7 +229,7 @@ String getEquals(List<NameType> fields, String className) {
   var sb = StringBuffer();
 
   sb.write(
-      "bool operator ==(Object other) => identical(this, other) || other is $className && runtimeType == other.runtimeType");
+      "@override\nbool operator ==(Object other) => identical(this, other) || other is $className && runtimeType == other.runtimeType");
 
   sb.writeln(fields.isEmpty ? "" : " &&");
 
@@ -521,7 +521,7 @@ String generateToJson(String className, List<NameType> generics) {
   Map<Type, Object? Function(Never)> _fns = {};
 
   Map<String, dynamic> toJson_2([Map<Type, Object? Function(Never)>? fns]){
-    this._fns = fns ?? {};
+    _fns = fns ?? {};
     return toJson();
   }
 

--- a/morphy/lib/src/helpers.dart
+++ b/morphy/lib/src/helpers.dart
@@ -206,13 +206,11 @@ String getInitializer(List<NameType> fields) {
 
 String getToString(List<NameType> fields, String className) {
   if (fields.isEmpty) {
-    return """@override\nString toString() => "($className-)""";
+    return """__String toString() => "($className-)""";
   }
 
-  var items = fields
-      .map((e) => "${e.name}:\${${e.name}.toString()}")
-      .joinToString(separator: "|");
-  return """@override\nString toString() => "($className-$items)";""";
+  var items = fields.map((e) => "${e.name}:\${${e.name}.toString()}").joinToString(separator: "|");
+  return """__String toString() => "($className-$items)";""";
 }
 
 String getHashCode(List<NameType> fields) {
@@ -220,16 +218,15 @@ String getHashCode(List<NameType> fields) {
     return "";
   }
 
-  var items =
-      fields.map((e) => "${e.name}.hashCode").joinToString(separator: ", ");
-  return """@override\nint get hashCode => hashObjects([$items]);""";
+  var items = fields.map((e) => "${e.name}.hashCode").joinToString(separator: ", ");
+  return """__int get hashCode => __hashObjects([$items]);""";
 }
 
 String getEquals(List<NameType> fields, String className) {
   var sb = StringBuffer();
 
-  sb.write(
-      "@override\nbool operator ==(Object other) => identical(this, other) || other is $className && runtimeType == other.runtimeType");
+  sb.write("__bool operator ==(__Object other) => __identical(this, other) || other is $className && runtimeType == other.runtimeType");
+
 
   sb.writeln(fields.isEmpty ? "" : " &&");
 
@@ -252,8 +249,7 @@ String getEquals(List<NameType> fields, String className) {
   return sb.toString();
 }
 
-String createJsonHeader(
-    String className, List<NameType> classGenerics, bool privateConstructor) {
+String createJsonHeader(String className, List<NameType> classGenerics, bool privateConstructor, bool explicitToJson) {
   var sb = StringBuffer();
 
   if (!className.startsWith("\$\$")) {
@@ -261,11 +257,9 @@ String createJsonHeader(
         privateConstructor ? "constructor: 'forJsonDoNotUse'" : "";
 
     if (classGenerics.length > 0) //
-      sb.writeln(
-          "@JsonSerializable(explicitToJson: true, genericArgumentFactories: true, $jsonConstructorName)");
+      sb.writeln("@JsonSerializable(explicitToJson: $explicitToJson, genericArgumentFactories: true, $jsonConstructorName)");
     else
-      sb.writeln(
-          "@JsonSerializable(explicitToJson: true, $jsonConstructorName)");
+      sb.writeln("@JsonSerializable(explicitToJson: $explicitToJson, $jsonConstructorName)");
   }
 
   return sb.toString();
@@ -453,7 +447,7 @@ String getConstructorName(String trimmedClassName, bool hasCustomConstructor) {
 String generateFromJsonHeader(String className) {
   var _className = "${className.replaceFirst("\$", "")}";
 
-  return "factory ${_className.replaceFirst("\$", "")}.fromJson(Map<String, dynamic> json) {";
+  return "factory ${_className.replaceFirst("\$", "")}.fromJson(__Map<__String, dynamic> json) {";
 }
 
 String generateFromJsonBody(
@@ -489,7 +483,7 @@ String generateFromJsonBody(
   var _className = className.replaceFirst("\$", "").replaceFirst("\$", "");
 
   var end = """    } else {
-      throw UnsupportedError("The _className_ '\${json['_className_']}' is not supported by the ${_className}.fromJson constructor.");
+      return _\$${_className}FromJson(json, );
     }
   }
 """;
@@ -499,7 +493,7 @@ String generateFromJsonBody(
 
 String generateToJson(String className, List<NameType> generics) {
   if (className.startsWith("\$\$")) {
-    return "Map<String, dynamic> toJson_2([Map<Type, Object? Function(Never)>? fns]);";
+    return "__Map<__String, dynamic> toJson_2([__Map<__Type, __Object? Function(__Never)>? fns]);";
   }
 
   var _className = "${className.replaceFirst("\$", "")}";
@@ -509,7 +503,7 @@ String generateToJson(String className, List<NameType> generics) {
       .join("\n");
 
   var toJsonParams = generics //
-      .map((e) => "      fn_${e.name} as Object? Function(${e.name})")
+      .map((e) => "      fn_${e.name} as __Object? Function(${e.name})")
       .join(",\n");
 
   var recordType = generics //
@@ -518,16 +512,16 @@ String generateToJson(String className, List<NameType> generics) {
 
   var result = """
   // ignore: unused_field
-  Map<Type, Object? Function(Never)> _fns = {};
+  __Map<__Type, __Object? Function(__Never)> _fns = {};
 
-  Map<String, dynamic> toJson_2([Map<Type, Object? Function(Never)>? fns]){
-    _fns = fns ?? {};
+  __Map<__String, dynamic> toJson_2([__Map<__Type, __Object? Function(__Never)>? fns]){
+    this._fns = fns ?? {};
     return toJson();
   }
 
-  Map<String, dynamic> toJson() {
+  __Map<__String, dynamic> toJson() {
 $getGenericFn
-    final Map<String, dynamic> data = _\$${_className}ToJson(this,
+    final __Map<__String, dynamic> data = _\$${_className}ToJson(this,
 $toJsonParams);
     // Adding custom key-value pair
     data['_className_'] = '$_className';
@@ -543,11 +537,11 @@ String createJsonSingleton(String classNameTrim, List<NameType> generics) {
   if (generics.length == 0) //
     return "";
 
-  var objects = generics.map((e) => "Object").join(", ");
+  var objects = generics.map((e) => "__Object").join(", ");
 
   var result = """
 class ${classNameTrim}_Generics_Sing {
-  Map<List<String>, $classNameTrim<${objects}> Function(Map<String, dynamic>)> fns = {};
+  __Map<__List<__String>, $classNameTrim<${objects}> Function(__Map<__String, dynamic>)> fns = {};
 
   factory ${classNameTrim}_Generics_Sing() => _singleton;
   static final ${classNameTrim}_Generics_Sing _singleton = ${classNameTrim}_Generics_Sing._internal();

--- a/morphy/pubspec.lock
+++ b/morphy/pubspec.lock
@@ -300,10 +300,11 @@ packages:
   morphy_annotation:
     dependency: "direct main"
     description:
-      path: "../morphy_annotation"
-      relative: true
-    source: path
-    version: "1.0.0"
+      name: morphy_annotation
+      sha256: "60c39351952712dfee416a71a69fbe7c0fecace38c95594814d04ed14ce098f7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   node_preamble:
     dependency: transitive
     description:

--- a/morphy/pubspec.yaml
+++ b/morphy/pubspec.yaml
@@ -1,17 +1,17 @@
 name: morphy
 description: Provides a clean class definition with extra functionality including; copy with, json serializable, tostring, equals that supports inheritance and polymorphism
-version: 1.5.0
+version: 2.0.0
 homepage: https://github.com/atreeon/morphy
 
 environment:
   sdk: ">=3.1.3 <4.0.0"
 
-dependency_overrides:
-  morphy_annotation:
-    path: ../morphy_annotation
+# dependency_overrides:
+#   morphy_annotation:
+#     path: ../morphy_annotation
 
 dependencies:
-  morphy_annotation: ^1.3.0
+  morphy_annotation: ^2.0.0
   analyzer: ">=6.0.0 <=7.0.0"
   build: ^2.1.0
   source_gen: ^1.1.1

--- a/morphy/pubspec.yaml
+++ b/morphy/pubspec.yaml
@@ -1,6 +1,6 @@
 name: morphy
 description: Provides a clean class definition with extra functionality including; copy with, json serializable, tostring, equals that supports inheritance and polymorphism
-version: 2.0.0
+version: 1.4.0
 homepage: https://github.com/atreeon/morphy
 
 environment:

--- a/morphy/pubspec.yaml
+++ b/morphy/pubspec.yaml
@@ -1,17 +1,17 @@
 name: morphy
 description: Provides a clean class definition with extra functionality including; copy with, json serializable, tostring, equals that supports inheritance and polymorphism
-version: 1.4.0
+version: 1.5.0
 homepage: https://github.com/atreeon/morphy
 
 environment:
   sdk: ">=3.1.3 <4.0.0"
 
-#dependency_overrides:
-#  morphy_annotation:
-#    path: ../morphy_annotation
+dependency_overrides:
+  morphy_annotation:
+    path: ../morphy_annotation
 
 dependencies:
-  morphy_annotation: ^1.1.0
+  morphy_annotation: ^1.3.0
   analyzer: ">=6.0.0 <=7.0.0"
   build: ^2.1.0
   source_gen: ^1.1.1

--- a/morphy/pubspec.yaml
+++ b/morphy/pubspec.yaml
@@ -6,9 +6,9 @@ homepage: https://github.com/atreeon/morphy
 environment:
   sdk: ">=3.1.3 <4.0.0"
 
-# dependency_overrides:
-#   morphy_annotation:
-#     path: ../morphy_annotation
+dependency_overrides:
+  morphy_annotation:
+    path: ../morphy_annotation
 
 dependencies:
   morphy_annotation: ^2.0.0

--- a/morphy/pubspec.yaml
+++ b/morphy/pubspec.yaml
@@ -1,6 +1,6 @@
 name: morphy
 description: Provides a clean class definition with extra functionality including; copy with, json serializable, tostring, equals that supports inheritance and polymorphism
-version: 1.3.0
+version: 2.0.0
 homepage: https://github.com/atreeon/morphy
 
 environment:
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   morphy_annotation: ^1.1.0
-  analyzer: '>=6.0.0 <=7.0.0'
+  analyzer: ">=6.0.0 <=7.0.0"
   build: ^2.1.0
   source_gen: ^1.1.1
   dartx: ^1.2.0

--- a/morphy/test/helpers_test.dart
+++ b/morphy/test/helpers_test.dart
@@ -346,7 +346,8 @@ void main() {
         NameTypeClassComment("c", "String", null),
       ], "MyClass");
 
-      expectS(result.toString(), """__String toString() => "(MyClass-a:\${a.toString()}|b:\${b.toString()}|c:\${c.toString()})";""");
+      expectS(result.toString(),
+          """__String toString() => "(MyClass-a:\${a.toString()}|b:\${b.toString()}|c:\${c.toString()})";""");
     });
   });
 
@@ -364,8 +365,7 @@ void main() {
         NameTypeClassComment("c", "String", null),
       ]);
 
-      expectS(
-          result.toString(), 
+      expectS(result.toString(),
           """__int get hashCode => __hashObjects([a.hashCode, b.hashCode, c.hashCode]);""");
     });
   });
@@ -373,7 +373,8 @@ void main() {
   group("getEquals", () {
     test("1i", () {
       var result = getEquals([], "A");
-      var expected = """__bool operator ==(__Object other) => __identical(this, other) || other is A && runtimeType == other.runtimeType
+      var expected =
+          """__bool operator ==(__Object other) => __identical(this, other) || other is A && runtimeType == other.runtimeType
 ;""";
 
       expectS(result, expected);
@@ -385,7 +386,8 @@ void main() {
         NameTypeClassComment("b", "String", null),
         NameTypeClassComment("c", "String", null),
       ], "C");
-      var expected = """__bool operator ==(__Object other) => __identical(this, other) || other is C && runtimeType == other.runtimeType &&
+      var expected =
+          """__bool operator ==(__Object other) => __identical(this, other) || other is C && runtimeType == other.runtimeType &&
 a == other.a && b == other.b && c == other.c;""";
 
       expectS(result, expected);
@@ -1501,8 +1503,8 @@ c: (this as C).c,
       var expected = """// ignore: unused_field\n
   __Map<__Type, __Object? Function(__Never)> _fns = {};
 
-  __Map<__String, dynamic> toJson_2([__Map<__Type, __Object? Function(__Never)>? fns]){
-    _fns = fns ?? {}; 
+  __Map<__String, dynamic> toJsonCustom([__Map<__Type, __Object? Function(__Never)>? fns]){
+    _fns = fns ?? {};
     return toJson();
   }
 
@@ -1530,10 +1532,10 @@ c: (this as C).c,
         ],
       );
 
-   var expected = """// ignore: unused_field\n  
+      var expected = """// ignore: unused_field\n
     __Map<__Type, __Object? Function(__Never)> _fns = {};
 
-    __Map<__String, dynamic> toJson_2([__Map<__Type, __Object? Function(__Never)>? fns]){
+    __Map<__String, dynamic> toJsonCustom([__Map<__Type, __Object? Function(__Never)>? fns]){
     _fns = fns ?? {};
     return toJson();
   }
@@ -1562,7 +1564,7 @@ c: (this as C).c,
       var result = generateToJson("\$\$Pet", []);
 
       var expected = """
-  __Map<__String, dynamic> toJson_2([__Map<__Type, __Object? Function(__Never)>? fns]);
+  __Map<__String, dynamic> toJsonCustom([__Map<__Type, __Object? Function(__Never)>? fns]);
 """;
 
       expectS(result, expected);
@@ -1631,7 +1633,8 @@ class C_Generics_Sing {
   group("createJsonHeader", () {
     test("1w non abstract, no generics, private constructor", () {
       var result = createJsonHeader("\$Pet", [], true, true);
-      var expected = "@JsonSerializable(explicitToJson: true, constructor: 'forJsonDoNotUse')";
+      var expected =
+          "@JsonSerializable(explicitToJson: true, constructor: 'forJsonDoNotUse')";
 
       expectS(result, expected);
     });
@@ -1644,8 +1647,10 @@ class C_Generics_Sing {
     });
 
     test("3w non abstract, generics, no private constructor", () {
-      var result = createJsonHeader("\$Pet", [NameTypeClass("name", "type", "className")], false, false);
-      var expected = "@JsonSerializable(explicitToJson: false, genericArgumentFactories: true, )";
+      var result = createJsonHeader(
+          "\$Pet", [NameTypeClass("name", "type", "className")], false, false);
+      var expected =
+          "@JsonSerializable(explicitToJson: false, genericArgumentFactories: true, )";
       expectS(result, expected);
     });
   });

--- a/morphy/test/helpers_test.dart
+++ b/morphy/test/helpers_test.dart
@@ -279,7 +279,8 @@ void main() {
         NameTypeClassComment("name", "String", null),
       ]);
 
-      expectS(result.toString(), "final int age;\nfinal String name;");
+      expectS(result.toString(),
+          "@override\nfinal int age;\n@override\nfinal String name;");
     });
 
     test("3f", () {
@@ -288,7 +289,7 @@ void main() {
       ]);
 
 //      expectS(result.toString(), "final \$BS a;");
-      expectS(result.toString(), "final BS a;");
+      expectS(result.toString(), "@override\nfinal BS a;");
     });
 
     test("4f", () {
@@ -297,7 +298,7 @@ void main() {
       ]);
 
 //      expectS(result.toString(), "final List<\$BS> a;");
-      expectS(result.toString(), "final List<BS> a;");
+      expectS(result.toString(), "@override\nfinal List<BS> a;");
     });
 
     test("5f", () {
@@ -306,7 +307,8 @@ void main() {
         NameTypeClassComment("name", "String", null, comment: "///blah"),
       ]);
 
-      expectS(result.toString(), "final int age;\n///blah\nfinal String name;");
+      expectS(result.toString(),
+          "@override\nfinal int age;\n///blah\n@override\nfinal String name;");
     });
 
     test("6f remove dollars from morphy types", () {
@@ -314,7 +316,8 @@ void main() {
         NameTypeClassComment("schedules", "List<\$ScheduleVM_Item>", null),
       ]);
 
-      expectS(result.toString(), "final List<ScheduleVM_Item> schedules;");
+      expectS(result.toString(),
+          "@override\nfinal List<ScheduleVM_Item> schedules;");
     });
 
     test(
@@ -325,8 +328,8 @@ void main() {
         NameTypeClassComment("name", "String", null, comment: "///blah"),
       ]);
 
-      expectS(
-          result.toString(), "final int _age;\n///blah\nfinal String name;");
+      expectS(result.toString(),
+          "@override\nfinal int _age;\n///blah\n@override\nfinal String name;");
     });
   });
 
@@ -334,7 +337,8 @@ void main() {
     test("1g", () {
       var result = getToString([], "MyClass");
 
-      expectS(result.toString(), """String toString() => "(MyClass-)""");
+      expectS(
+          result.toString(), """@override\nString toString() => "(MyClass-)""");
     });
 
     test("2g", () {
@@ -345,7 +349,7 @@ void main() {
       ], "MyClass");
 
       expectS(result.toString(),
-          """String toString() => "(MyClass-a:\${a.toString()}|b:\${b.toString()}|c:\${c.toString()})";""");
+          """@override\nString toString() => "(MyClass-a:\${a.toString()}|b:\${b.toString()}|c:\${c.toString()})";""");
     });
   });
 
@@ -365,7 +369,7 @@ void main() {
 
       expectS(
           result.toString(), //
-          """int get hashCode => hashObjects([a.hashCode, b.hashCode, c.hashCode]);""");
+          """@override\nint get hashCode => hashObjects([a.hashCode, b.hashCode, c.hashCode]);""");
     });
   });
 
@@ -374,7 +378,7 @@ void main() {
       var result = getEquals([], "A");
 
       var expected =
-          """bool operator ==(Object other) => identical(this, other) || other is A && runtimeType == other.runtimeType
+          """@override\nbool operator ==(Object other) => identical(this, other) || other is A && runtimeType == other.runtimeType
 ;""";
 
       expectS(result, expected);
@@ -388,7 +392,7 @@ void main() {
       ], "C");
 
       var expected =
-          """bool operator ==(Object other) => identical(this, other) || other is C && runtimeType == other.runtimeType &&
+          """@override\nbool operator ==(Object other) => identical(this, other) || other is C && runtimeType == other.runtimeType &&
 a == other.a && b == other.b && c == other.c;""";
 
       expectS(result, expected);
@@ -1161,7 +1165,7 @@ fn: fn == null ? this.fn as bool Function(\$X) : fn() as bool Function(\$X),
         isClassAbstract: false,
         isExplicitSubType: true,
       );
-      expectS(result, """B changeTo_B({
+      expectS(result, """B changeToB({
 required String y,
 String Function()? x,
 }) {
@@ -1187,7 +1191,7 @@ x: x == null ? this.x as String : x() as String,
         isClassAbstract: false,
         isExplicitSubType: true,
       );
-      expectS(result, """B changeTo_B({
+      expectS(result, """B changeToB({
 required String y,
 required Z z,
 String Function()? x,
@@ -1215,7 +1219,7 @@ x: x == null ? this.x as String : x() as String,
         isClassAbstract: false,
         isExplicitSubType: true,
       );
-      expectS(result, """B changeTo_B({
+      expectS(result, """B changeToB({
 required String y,
 required Z z,
 String Function()? x,
@@ -1271,7 +1275,7 @@ z: z == null ? this.z as Z : z() as Z,
         isClassAbstract: true,
         isExplicitSubType: true,
       );
-      expectS(result, """B changeTo_B({
+      expectS(result, """B changeToB({
 required String y,
 String Function()? x,
 }) {
@@ -1297,7 +1301,7 @@ x: x == null ? this.x as String : x() as String,
         isClassAbstract: false,
         isExplicitSubType: true,
       );
-      expectS(result, """B changeTo_B({
+      expectS(result, """B changeToB({
 required String y,
 required Z z,
 String Function()? x,
@@ -1505,7 +1509,7 @@ c: (this as C).c,
   Map<Type, Object? Function(Never)> _fns = {};
 
   Map<String, dynamic> toJson_2([Map<Type, Object? Function(Never)>? fns]){
-    this._fns = fns ?? {};
+    _fns = fns ?? {};
     return toJson();
   }
 
@@ -1537,7 +1541,7 @@ c: (this as C).c,
   Map<Type, Object? Function(Never)> _fns = {};
 
   Map<String, dynamic> toJson_2([Map<Type, Object? Function(Never)>? fns]){
-    this._fns = fns ?? {};
+    _fns = fns ?? {};
     return toJson();
   }
 

--- a/morphy/test/helpers_test.dart
+++ b/morphy/test/helpers_test.dart
@@ -336,9 +336,7 @@ void main() {
   group("getToString", () {
     test("1g", () {
       var result = getToString([], "MyClass");
-
-      expectS(
-          result.toString(), """@override\nString toString() => "(MyClass-)""");
+      expectS(result.toString(), """__String toString() => "(MyClass-)""");
     });
 
     test("2g", () {
@@ -348,8 +346,7 @@ void main() {
         NameTypeClassComment("c", "String", null),
       ], "MyClass");
 
-      expectS(result.toString(),
-          """@override\nString toString() => "(MyClass-a:\${a.toString()}|b:\${b.toString()}|c:\${c.toString()})";""");
+      expectS(result.toString(), """__String toString() => "(MyClass-a:\${a.toString()}|b:\${b.toString()}|c:\${c.toString()})";""");
     });
   });
 
@@ -368,17 +365,15 @@ void main() {
       ]);
 
       expectS(
-          result.toString(), //
-          """@override\nint get hashCode => hashObjects([a.hashCode, b.hashCode, c.hashCode]);""");
+          result.toString(), 
+          """__int get hashCode => __hashObjects([a.hashCode, b.hashCode, c.hashCode]);""");
     });
   });
 
   group("getEquals", () {
     test("1i", () {
       var result = getEquals([], "A");
-
-      var expected =
-          """@override\nbool operator ==(Object other) => identical(this, other) || other is A && runtimeType == other.runtimeType
+      var expected = """__bool operator ==(__Object other) => __identical(this, other) || other is A && runtimeType == other.runtimeType
 ;""";
 
       expectS(result, expected);
@@ -390,9 +385,7 @@ void main() {
         NameTypeClassComment("b", "String", null),
         NameTypeClassComment("c", "String", null),
       ], "C");
-
-      var expected =
-          """@override\nbool operator ==(Object other) => identical(this, other) || other is C && runtimeType == other.runtimeType &&
+      var expected = """__bool operator ==(__Object other) => __identical(this, other) || other is C && runtimeType == other.runtimeType &&
 a == other.a && b == other.b && c == other.c;""";
 
       expectS(result, expected);
@@ -1377,7 +1370,7 @@ c: (this as C).c,
   group("generateFromJsonHeader", () {
     test("1r ", () {
       var result = generateFromJsonHeader("\$Pet");
-      expectS(result, "factory Pet.fromJson(Map<String, dynamic> json) {");
+      expectS(result, "factory Pet.fromJson(__Map<__String, dynamic> json) {");
     });
   });
 
@@ -1506,16 +1499,16 @@ c: (this as C).c,
       var result = generateToJson("\$Pet", []);
 
       var expected = """// ignore: unused_field\n
-  Map<Type, Object? Function(Never)> _fns = {};
+  __Map<__Type, __Object? Function(__Never)> _fns = {};
 
-  Map<String, dynamic> toJson_2([Map<Type, Object? Function(Never)>? fns]){
-    _fns = fns ?? {};
+  __Map<__String, dynamic> toJson_2([__Map<__Type, __Object? Function(__Never)>? fns]){
+    _fns = fns ?? {}; 
     return toJson();
   }
 
-  Map<String, dynamic> toJson() {
+  __Map<__String, dynamic> toJson() {
 
-    final Map<String, dynamic> data = _\$PetToJson(this,
+    final __Map<__String, dynamic> data = _\$PetToJson(this,
 );
     // Adding custom key-value pair
     data['_className_'] = 'Pet';
@@ -1537,22 +1530,22 @@ c: (this as C).c,
         ],
       );
 
-      var expected = """// ignore: unused_field\n
-  Map<Type, Object? Function(Never)> _fns = {};
+   var expected = """// ignore: unused_field\n  
+    __Map<__Type, __Object? Function(__Never)> _fns = {};
 
-  Map<String, dynamic> toJson_2([Map<Type, Object? Function(Never)>? fns]){
+    __Map<__String, dynamic> toJson_2([__Map<__Type, __Object? Function(__Never)>? fns]){
     _fns = fns ?? {};
     return toJson();
   }
 
-  Map<String, dynamic> toJson() {
+  __Map<__String, dynamic> toJson() {
     var fn_T = getGenericToJsonFn(_fns, T);
     var fn_T2 = getGenericToJsonFn(_fns, T2);
     var fn_T3 = getGenericToJsonFn(_fns, T3);
-    final Map<String, dynamic> data = _\$PetToJson(this,
-      fn_T as Object? Function(T),
-      fn_T2 as Object? Function(T2),
-      fn_T3 as Object? Function(T3));
+    final __Map<__String, dynamic> data = _\$PetToJson(this,
+      fn_T as __Object? Function(T),
+      fn_T2 as __Object? Function(T2),
+      fn_T3 as __Object? Function(T3));
     // Adding custom key-value pair
     data['_className_'] = 'Pet';
     data['_T_'] = T.toString();
@@ -1569,7 +1562,7 @@ c: (this as C).c,
       var result = generateToJson("\$\$Pet", []);
 
       var expected = """
-  Map<String, dynamic> toJson_2([Map<Type, Object? Function(Never)>? fns]);
+  __Map<__String, dynamic> toJson_2([__Map<__Type, __Object? Function(__Never)>? fns]);
 """;
 
       expectS(result, expected);
@@ -1587,7 +1580,7 @@ c: (this as C).c,
 
       var expected = """
 class B_Generics_Sing {
-  Map<List<String>, B<Object> Function(Map<String, dynamic>)> fns = {};
+  __Map<__List<__String>, B<__Object> Function(__Map<__String, dynamic>)> fns = {};
 
   factory B_Generics_Sing() => _singleton;
   static final B_Generics_Sing _singleton = B_Generics_Sing._internal();
@@ -1611,7 +1604,7 @@ class B_Generics_Sing {
 
       var expected = """
 class C_Generics_Sing {
-  Map<List<String>, C<Object, Object, Object> Function(Map<String, dynamic>)> fns = {};
+  __Map<__List<__String>, C<__Object, __Object, __Object> Function(__Map<__String, dynamic>)> fns = {};
 
   factory C_Generics_Sing() => _singleton;
   static final C_Generics_Sing _singleton = C_Generics_Sing._internal();
@@ -1637,26 +1630,22 @@ class C_Generics_Sing {
 
   group("createJsonHeader", () {
     test("1w non abstract, no generics, private constructor", () {
-      var result = createJsonHeader("\$Pet", [], true);
-      var expected =
-          "@JsonSerializable(explicitToJson: true, constructor: 'forJsonDoNotUse')";
+      var result = createJsonHeader("\$Pet", [], true, true);
+      var expected = "@JsonSerializable(explicitToJson: true, constructor: 'forJsonDoNotUse')";
 
       expectS(result, expected);
     });
 
     test("2w abstract", () {
-      var result = createJsonHeader("\$\$Pet", [], true);
+      var result = createJsonHeader("\$\$Pet", [], true, true);
       var expected = "";
 
       expectS(result, expected);
     });
 
     test("3w non abstract, generics, no private constructor", () {
-      var result = createJsonHeader(
-          "\$Pet", [NameTypeClass("name", "type", "className")], false);
-      var expected =
-          "@JsonSerializable(explicitToJson: true, genericArgumentFactories: true, )";
-
+      var result = createJsonHeader("\$Pet", [NameTypeClass("name", "type", "className")], false, false);
+      var expected = "@JsonSerializable(explicitToJson: false, genericArgumentFactories: true, )";
       expectS(result, expected);
     });
   });

--- a/morphy/test/helpers_test.dart
+++ b/morphy/test/helpers_test.dart
@@ -279,8 +279,7 @@ void main() {
         NameTypeClassComment("name", "String", null),
       ]);
 
-      expectS(result.toString(),
-          "@override\nfinal int age;\n@override\nfinal String name;");
+      expectS(result.toString(), "final int age;\nfinal String name;");
     });
 
     test("3f", () {
@@ -289,7 +288,7 @@ void main() {
       ]);
 
 //      expectS(result.toString(), "final \$BS a;");
-      expectS(result.toString(), "@override\nfinal BS a;");
+      expectS(result.toString(), "final BS a;");
     });
 
     test("4f", () {
@@ -298,7 +297,7 @@ void main() {
       ]);
 
 //      expectS(result.toString(), "final List<\$BS> a;");
-      expectS(result.toString(), "@override\nfinal List<BS> a;");
+      expectS(result.toString(), "final List<BS> a;");
     });
 
     test("5f", () {
@@ -307,8 +306,7 @@ void main() {
         NameTypeClassComment("name", "String", null, comment: "///blah"),
       ]);
 
-      expectS(result.toString(),
-          "@override\nfinal int age;\n///blah\n@override\nfinal String name;");
+      expectS(result.toString(), "final int age;\n///blah\nfinal String name;");
     });
 
     test("6f remove dollars from morphy types", () {
@@ -316,8 +314,7 @@ void main() {
         NameTypeClassComment("schedules", "List<\$ScheduleVM_Item>", null),
       ]);
 
-      expectS(result.toString(),
-          "@override\nfinal List<ScheduleVM_Item> schedules;");
+      expectS(result.toString(), "final List<ScheduleVM_Item> schedules;");
     });
 
     test(
@@ -328,8 +325,8 @@ void main() {
         NameTypeClassComment("name", "String", null, comment: "///blah"),
       ]);
 
-      expectS(result.toString(),
-          "@override\nfinal int _age;\n///blah\n@override\nfinal String name;");
+      expectS(
+          result.toString(), "final int _age;\n///blah\nfinal String name;");
     });
   });
 
@@ -1382,7 +1379,6 @@ c: (this as C).c,
 
       var expected = """
     if (json['_className_'] == "Pet") {
-
       return _\$PetFromJson(json, );
     } else {
       throw UnsupportedError("The _className_ '\${json['_className_']}' is not supported by the Pet.fromJson constructor.");

--- a/morphy/test/helpers_test.dart
+++ b/morphy/test/helpers_test.dart
@@ -5,7 +5,8 @@ import 'package:morphy/src/common/formatCodeStringForComparison.dart';
 import 'package:morphy/src/helpers.dart';
 import 'package:test/test.dart';
 
-var expectS = (String a, String b) => expect(formatCodeStringForComparison(a), formatCodeStringForComparison(b));
+var expectS = (String a, String b) =>
+    expect(formatCodeStringForComparison(a), formatCodeStringForComparison(b));
 
 void main() {
   group("getClassComment", () {
@@ -42,9 +43,11 @@ void main() {
 
     test("3x with all comments", () {
       var interfaces = [
-        InterfaceWithComment("\$A", ["int", "String"], ["T1", "T2"], [], comment: "///blah1"),
+        InterfaceWithComment("\$A", ["int", "String"], ["T1", "T2"], [],
+            comment: "///blah1"),
         InterfaceWithComment("\$A", ["int", "String"], ["T1", "T2"], []),
-        InterfaceWithComment("\$A", ["int", "String"], ["T1", "T2"], [], comment: "///blah2"),
+        InterfaceWithComment("\$A", ["int", "String"], ["T1", "T2"], [],
+            comment: "///blah2"),
       ];
 
       var result = getClassComment(interfaces, "///blah");
@@ -171,19 +174,22 @@ void main() {
 
   group("getClassDefinition", () {
     test("1b", () {
-      var result = getClassDefinition(isAbstract: false, nonSealed: false, className: "\$Pet");
+      var result = getClassDefinition(
+          isAbstract: false, nonSealed: false, className: "\$Pet");
 
       expectS(result, "class Pet");
     });
 
     test("2b", () {
-      var result = getClassDefinition(isAbstract: true, nonSealed: false, className: "\$\$Pet");
+      var result = getClassDefinition(
+          isAbstract: true, nonSealed: false, className: "\$\$Pet");
 
       expectS(result, "sealed class Pet");
     });
 
     test("3b", () {
-      var result = getClassDefinition(isAbstract: true, nonSealed: true, className: "\$\$Pet");
+      var result = getClassDefinition(
+          isAbstract: true, nonSealed: true, className: "\$\$Pet");
 
       expectS(result, "abstract class Pet");
     });
@@ -209,7 +215,8 @@ void main() {
 
   group("getExtendsGenerics", () {
     test("1d", () {
-      var result = getExtendsGenerics([NameTypeClassComment("T", "\$\$C", null)]);
+      var result =
+          getExtendsGenerics([NameTypeClassComment("T", "\$\$C", null)]);
 
       expectS(result, "<T>");
     });
@@ -310,13 +317,16 @@ void main() {
       expectS(result.toString(), "final List<ScheduleVM_Item> schedules;");
     });
 
-    test("7f private properties (get turned into public getters & private setters)", () {
+    test(
+        "7f private properties (get turned into public getters & private setters)",
+        () {
       var result = getProperties([
         NameTypeClassComment("_age", "int", null),
         NameTypeClassComment("name", "String", null, comment: "///blah"),
       ]);
 
-      expectS(result.toString(), "final int _age;\n///blah\nfinal String name;");
+      expectS(
+          result.toString(), "final int _age;\n///blah\nfinal String name;");
     });
   });
 
@@ -334,7 +344,8 @@ void main() {
         NameTypeClassComment("c", "String", null),
       ], "MyClass");
 
-      expectS(result.toString(), """String toString() => "(MyClass-a:\${a.toString()}|b:\${b.toString()}|c:\${c.toString()})";""");
+      expectS(result.toString(),
+          """String toString() => "(MyClass-a:\${a.toString()}|b:\${b.toString()}|c:\${c.toString()})";""");
     });
   });
 
@@ -362,7 +373,8 @@ void main() {
     test("1i", () {
       var result = getEquals([], "A");
 
-      var expected = """bool operator ==(Object other) => identical(this, other) || other is A && runtimeType == other.runtimeType
+      var expected =
+          """bool operator ==(Object other) => identical(this, other) || other is A && runtimeType == other.runtimeType
 ;""";
 
       expectS(result, expected);
@@ -375,7 +387,8 @@ void main() {
         NameTypeClassComment("c", "String", null),
       ], "C");
 
-      var expected = """bool operator ==(Object other) => identical(this, other) || other is C && runtimeType == other.runtimeType &&
+      var expected =
+          """bool operator ==(Object other) => identical(this, other) || other is C && runtimeType == other.runtimeType &&
 a == other.a && b == other.b && c == other.c;""";
 
       expectS(result, expected);
@@ -404,7 +417,8 @@ a == other.a && b == other.b && c == other.c;""";
         NameTypeClassComment("name", "String", null),
       ]);
 
-      expectS(result.toString(), "///blah blah\nint get age;\nString get name;");
+      expectS(
+          result.toString(), "///blah blah\nint get age;\nString get name;");
     });
   });
 
@@ -439,7 +453,8 @@ a == other.a && b == other.b && c == other.c;""";
         ],
       );
 
-      expectS(result.toString(), "required this.age,\nrequired this.listOfStrings,");
+      expectS(result.toString(),
+          "required this.age,\nrequired this.listOfStrings,");
     });
 
     test("5k private properties not null", () {
@@ -467,7 +482,7 @@ a == other.a && b == other.b && c == other.c;""";
 
   group("get intializer list", () {
     test("1l with a private", () {
-      var result = getInitialiser(
+      var result = getInitializer(
         [
           NameTypeClassComment("_age", "int?", null),
           NameTypeClassComment("name", "String?", null),
@@ -478,7 +493,7 @@ a == other.a && b == other.b && c == other.c;""";
     });
 
     test("2l without a private", () {
-      var result = getInitialiser(
+      var result = getInitializer(
         [
           NameTypeClassComment("age", "int?", null),
           NameTypeClassComment("name", "String?", null),
@@ -509,8 +524,11 @@ a == other.a && b == other.b && c == other.c;""";
       expectS(result, "Word");
     });
 
-    test("4m if a Function data type and we have a morphy class then don't remove", () {
-      var result = removeDollarsFromPropertyType("bool Function(int blah, \$X blim)");
+    test(
+        "4m if a Function data type and we have a morphy class then don't remove",
+        () {
+      var result =
+          removeDollarsFromPropertyType("bool Function(int blah, \$X blim)");
       expectS(result, "bool Function(int blah, \$X blim)");
     });
   });
@@ -563,7 +581,7 @@ a == other.a && b == other.b && c == other.c;""";
         isClassAbstract: true,
         interfaceGenerics: [],
       );
-      expectS(result, """A copyWith_A({
+      expectS(result, """A copyWithA({
 String Function()? a,
 });""");
     });
@@ -582,7 +600,7 @@ String Function()? a,
         isClassAbstract: true,
         interfaceGenerics: [],
       );
-      expectS(result, """A copyWith_A({
+      expectS(result, """A copyWithA({
 int Function()? a,
 });""");
     });
@@ -600,7 +618,7 @@ int Function()? a,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """A copyWith_A({
+      expectS(result, """A copyWithA({
 String Function()? a,
 }) {
 return A._(
@@ -622,7 +640,7 @@ a: a == null ? this.a as String : a() as String,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """A copyWith_A({
+      expectS(result, """A copyWithA({
 String Function()? a,
 }) {
 return B._(
@@ -646,7 +664,7 @@ b: (this as B).b,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """B copyWith_B({
+      expectS(result, """B copyWithB({
 String Function()? a,
 T1 Function()? b,
 }) {
@@ -671,7 +689,7 @@ b: b == null ? this.b as T1 : b() as T1,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """A copyWith_A({
+      expectS(result, """A copyWithA({
 String Function()? a,
 }) {
 return C._(
@@ -697,7 +715,7 @@ c: (this as C).c,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """B copyWith_B({
+      expectS(result, """B copyWithB({
 String Function()? a,
 T1 Function()? b,
 }) {
@@ -725,7 +743,7 @@ c: (this as C).c,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """C copyWith_C({
+      expectS(result, """C copyWithC({
 String Function()? a,
 T1 Function()? b,
 bool Function()? c,
@@ -751,7 +769,7 @@ c: c == null ? this.c as bool : c() as bool,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """A copyWith_A({
+      expectS(result, """A copyWithA({
 String Function()? a,
 }) {
 return D._(
@@ -775,7 +793,7 @@ b: (this as D).b,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """B copyWith_B({
+      expectS(result, """B copyWithB({
 String Function()? a,
 T1 Function()? b,
 }) {
@@ -800,7 +818,7 @@ b: b == null ? this.b as T1 : b() as T1,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """D copyWith_D({
+      expectS(result, """D copyWithD({
 String Function()? a,
 T1 Function()? b,
 }) {
@@ -819,7 +837,7 @@ b: b == null ? this.b as T1 : b() as T1,
         isClassAbstract: true,
         interfaceGenerics: [],
       );
-      expectS(result, """X copyWith_X(
+      expectS(result, """X copyWithX(
 );""");
     });
 
@@ -834,7 +852,7 @@ b: b == null ? this.b as T1 : b() as T1,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """X copyWith_X(
+      expectS(result, """X copyWithX(
 ) {
 return Y._(
 a: (this as Y).a,
@@ -854,7 +872,7 @@ a: (this as Y).a,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """Y copyWith_Y({
+      expectS(result, """Y copyWithY({
 String Function()? a,
 }) {
 return Y._(
@@ -875,7 +893,7 @@ a: a == null ? this.a as String : a() as String,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """A copyWith_A({
+      expectS(result, """A copyWithA({
 Person Function()? a,
 }) {
 return A._(
@@ -896,7 +914,7 @@ a: a == null ? this.a as Person : a() as Person,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """A copyWith_A({
+      expectS(result, """A copyWithA({
 Person Function()? a,
 }) {
 return B._(
@@ -917,7 +935,7 @@ a: a == null ? this.a as Employee : a() as Employee,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """B copyWith_B({
+      expectS(result, """B copyWithB({
 Employee Function()? a,
 }) {
 return B._(
@@ -938,7 +956,7 @@ a: a == null ? this.a as Employee : a() as Employee,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """A copyWith_A({
+      expectS(result, """A copyWithA({
 Person Function()? a,
 }) {
 return C._(
@@ -959,7 +977,7 @@ a: a == null ? this.a as Manager : a() as Manager,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """B copyWith_B({
+      expectS(result, """B copyWithB({
 Employee Function()? a,
 }) {
 return C._(
@@ -980,7 +998,7 @@ a: a == null ? this.a as Manager : a() as Manager,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """C copyWith_C({
+      expectS(result, """C copyWithC({
 Manager Function()? a,
 }) {
 return C._(
@@ -1004,7 +1022,7 @@ a: a == null ? this.a as Manager : a() as Manager,
         className: "B",
         isClassAbstract: false,
       );
-      expectS(result, """A<T1, T2> copyWith_A<T1, T2>({
+      expectS(result, """A<T1, T2> copyWithA<T1, T2>({
 T1 Function()? x,
 T2 Function()? y,
 }) {
@@ -1032,7 +1050,7 @@ z: (this as B).z,
         className: "B",
         isClassAbstract: false,
       );
-      expectS(result, """B copyWith_B({
+      expectS(result, """B copyWithB({
 int Function()? x,
 String Function()? y,
 String Function()? z,
@@ -1057,7 +1075,7 @@ z: z == null ? this.z as String : z() as String,
         className: "A",
         isClassAbstract: true,
       );
-      expectS(result, """A<T> copyWith_A<T>({
+      expectS(result, """A<T> copyWithA<T>({
 T Function()? x,
 });""");
     });
@@ -1077,7 +1095,7 @@ T Function()? x,
         className: "B",
         isClassAbstract: false,
       );
-      expectS(result, """A<T> copyWith_A<T>({
+      expectS(result, """A<T> copyWithA<T>({
 T Function()? x,
 }) {
 return B._(
@@ -1099,7 +1117,7 @@ y: (this as B).y,
         className: "A",
         isClassAbstract: false,
       );
-      expectS(result, """A copyWith_A({
+      expectS(result, """A copyWithA({
 String Function()? a,
 }) {
 return A._(
@@ -1120,7 +1138,7 @@ a: a == null ? this.a as String : a() as String,
         className: "X",
         isClassAbstract: false,
       );
-      expectS(result, """X copyWith_X({
+      expectS(result, """X copyWithX({
 bool Function(\$X) Function()? fn,
 }) {
 return X._(
@@ -1226,7 +1244,7 @@ x: x == null ? this.x as String : x() as String,
         className: "\$B",
         isClassAbstract: false,
       );
-      expectS(result, """B copyWith_B({
+      expectS(result, """B copyWithB({
 String Function()? x,
 List<C> Function()? cs,
 Z Function()? z,
@@ -1304,7 +1322,7 @@ x: x == null ? this.x as String : x() as String,
         isClassAbstract: true,
         interfaceGenerics: [],
       );
-      expectS(result, """A copyWith_A({
+      expectS(result, """A copyWithA({
 String Function()? a,
 });""");
     });
@@ -1325,7 +1343,7 @@ String Function()? a,
         isClassAbstract: false,
         interfaceGenerics: [],
       );
-      expectS(result, """B copyWith_B({
+      expectS(result, """B copyWithB({
 String Function()? a,
 T1 Function()? b,
 }) {
@@ -1343,8 +1361,11 @@ c: (this as C).c,
       expectS(result, "Word");
     });
 
-    test("2q if a Function data type and we have a morphy class then don't remove", () {
-      var result = getDataTypeWithoutDollars("bool Function(int blah, \$X blim)");
+    test(
+        "2q if a Function data type and we have a morphy class then don't remove",
+        () {
+      var result =
+          getDataTypeWithoutDollars("bool Function(int blah, \$X blim)");
       expectS(result, "bool Function(int blah, \$X blim)");
     });
   });
@@ -1383,7 +1404,7 @@ c: (this as C).c,
 
       var expected = """
     if (json['_className_'] == "Manager") {
-      return _\$ManagerFromJson(json, );            
+      return _\$ManagerFromJson(json, );
     } else if (json['_className_'] == "Person") {
       return _\$PersonFromJson(json, );
     } else {
@@ -1439,7 +1460,7 @@ c: (this as C).c,
     );
     return fn_fromJson(json);
   } else if (json[\'_className_\'] == "A") {
-    return _\$AFromJson(json, ); 
+    return _\$AFromJson(json, );
   } else {
     throw UnsupportedError("The _className_ '\${json['_className_']}' is not supported by the A.fromJson constructor.");
   }
@@ -1512,7 +1533,7 @@ c: (this as C).c,
         ],
       );
 
-      var expected = """// ignore: unused_field\n  
+      var expected = """// ignore: unused_field\n
   Map<Type, Object? Function(Never)> _fns = {};
 
   Map<String, dynamic> toJson_2([Map<Type, Object? Function(Never)>? fns]){
@@ -1613,7 +1634,8 @@ class C_Generics_Sing {
   group("createJsonHeader", () {
     test("1w non abstract, no generics, private constructor", () {
       var result = createJsonHeader("\$Pet", [], true);
-      var expected = "@JsonSerializable(explicitToJson: true, constructor: 'forJsonDoNotUse')";
+      var expected =
+          "@JsonSerializable(explicitToJson: true, constructor: 'forJsonDoNotUse')";
 
       expectS(result, expected);
     });
@@ -1626,8 +1648,10 @@ class C_Generics_Sing {
     });
 
     test("3w non abstract, generics, no private constructor", () {
-      var result = createJsonHeader("\$Pet", [NameTypeClass("name", "type", "className")], false);
-      var expected = "@JsonSerializable(explicitToJson: true, genericArgumentFactories: true, )";
+      var result = createJsonHeader(
+          "\$Pet", [NameTypeClass("name", "type", "className")], false);
+      var expected =
+          "@JsonSerializable(explicitToJson: true, genericArgumentFactories: true, )";
 
       expectS(result, expected);
     });
@@ -1642,7 +1666,7 @@ class C_Generics_Sing {
 //        ],
 //        "A",
 //      );
-//      expectS(result, """A copyWith_A({
+//      expectS(result, """A copyWithA({
 //required int a,
 //required String? b,
 //}) {""");

--- a/morphy_annotation/lib/src/annotations.dart
+++ b/morphy_annotation/lib/src/annotations.dart
@@ -1,12 +1,14 @@
 import 'package:collection/collection.dart';
 
 /// {@macro MorphyX}
-const morphy = Morphy(generateJson: false, explicitSubTypes: null);
+const morphy =
+    Morphy(generateJson: false, explicitSubTypes: null, explicitToJson: true);
 
 /// ### Morphy2 will be created before Morphy, sometimes the generator needs a related class to be built before another.
 /// ---
 /// {@macro MorphyX}
-const morphy2 = Morphy2(generateJson: false, explicitSubTypes: null);
+const morphy2 =
+    Morphy2(generateJson: false, explicitSubTypes: null, explicitToJson: true);
 
 class Morphy implements MorphyX {
   /// if we want a copyWith (cwX) method for a subtype in this same class
@@ -145,7 +147,9 @@ dynamic getFromJsonToGenericFn(
 ) {
   var types = genericType.map((e) => json[e]).toList();
 
-  var fromJsonToGeneric_fn = fns.entries.firstWhereOrNull((entry) => ListEquality().equals(entry.key, types))?.value;
+  var fromJsonToGeneric_fn = fns.entries
+      .firstWhereOrNull((entry) => ListEquality().equals(entry.key, types))
+      ?.value;
   if (fromJsonToGeneric_fn == null) //
     throw Exception("From JSON function not found");
   return fromJsonToGeneric_fn;

--- a/morphy_annotation/lib/src/annotations.dart
+++ b/morphy_annotation/lib/src/annotations.dart
@@ -13,6 +13,7 @@ class Morphy implements MorphyX {
   final List<Type>? explicitSubTypes;
 
   final bool generateJson;
+  final bool explicitToJson;
 
   final bool hidePublicConstructor;
 
@@ -96,6 +97,7 @@ class Morphy implements MorphyX {
   const Morphy({
     this.explicitSubTypes = null,
     this.generateJson = false,
+    this.explicitToJson = true,
     this.hidePublicConstructor = false,
     this.nonSealed = false,
   });
@@ -104,12 +106,14 @@ class Morphy implements MorphyX {
 class Morphy2 implements MorphyX {
   final List<Type>? explicitSubTypes;
   final bool generateJson;
+  final bool explicitToJson;
   final bool hidePublicConstructor;
   final bool nonSealed;
 
   const Morphy2({
     this.explicitSubTypes = null,
     this.generateJson = false,
+    this.explicitToJson = true,
     this.hidePublicConstructor = false,
     this.nonSealed = false,
   });
@@ -119,6 +123,7 @@ abstract class MorphyX {
   List<Type>? get explicitSubTypes;
 
   bool get generateJson;
+  bool get explicitToJson;
 }
 
 Object? Function(Never) getGenericToJsonFn(

--- a/morphy_annotation/pubspec.lock
+++ b/morphy_annotation/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  json_annotation:
+    dependency: "direct main"
+    description:
+      name: json_annotation
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.9.0"
   matcher:
     dependency: transitive
     description:

--- a/morphy_annotation/pubspec.yaml
+++ b/morphy_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: morphy_annotation
 description: annotation for morphy which provides a clean class definition with extra functionality including; copy with, json serializable, tostring, equals that supports inheritance and polymorphism
-version: 1.3.0
+version: 1.4.0
 homepage: https://github.com/atreeon/morphy
 
 environment:
@@ -11,6 +11,3 @@ dependencies:
   dartx: ^1.2.0
   json_annotation: ^4.7.0
   quiver: ^3.0.1
-
-
-

--- a/morphy_annotation/pubspec.yaml
+++ b/morphy_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: morphy_annotation
 description: annotation for morphy which provides a clean class definition with extra functionality including; copy with, json serializable, tostring, equals that supports inheritance and polymorphism
-version: 1.4.0
+version: 2.0.0
 homepage: https://github.com/atreeon/morphy
 
 environment:


### PR DESCRIPTION
This PR follows Dart naming conventions for better readibilty and prevent unncessary warnings on IDE.
I adde the PRs from @miklcct 

I updated helper test file accordingly to pass the tests.
a new generated file looks like this
```dart
// ignore_for_file: UNNECESSARY_CAST
// ignore_for_file: type=lint

part of 'zik_zak_user.dart';

// **************************************************************************
// Generator: MorphyGenerator<Morphy>
// **************************************************************************

typedef __String = String;
typedef __Object = Object;
// ignore: unused_element
typedef __List<E> = List<E>;
typedef __Map<K, V> = Map<K, V>;
typedef __Never = Never;
typedef __Type = Type;
typedef __int = int;
typedef __bool = bool;
const __hashObjects = hashObjects;
const __identical = identical;

///

@JsonSerializable(
  explicitToJson: true,
)
class ZikZakUser extends $ZikZakUser {
  final String type;
  final int id;

  ///
  ZikZakUser({
    required this.type,
    required this.id,
  });
  ZikZakUser._({
    required this.type,
    required this.id,
  });
  __String toString() =>
      "(ZikZakUser-type:${type.toString()}|id:${id.toString()})";
  __int get hashCode => __hashObjects([type.hashCode, id.hashCode]);
  __bool operator ==(__Object other) =>
      __identical(this, other) ||
      other is ZikZakUser &&
          runtimeType == other.runtimeType &&
          type == other.type &&
          id == other.id;
  ZikZakUser copyWithZikZakUser({
    String Function()? type,
    int Function()? id,
  }) {
    return ZikZakUser._(
      type: type == null ? this.type as String : type() as String,
      id: id == null ? this.id as int : id() as int,
    ) as ZikZakUser;
  }

//$ZikZakUser|[]|[type:String:null, id:int:null]
//
  factory ZikZakUser.fromJson(__Map<__String, dynamic> json) {
    if (json['_className_'] == "ZikZakUser") {
      return _$ZikZakUserFromJson(
        json,
      );
    } else {
      throw UnsupportedError(
          "The _className_ '${json['_className_']}' is not supported by the ZikZakUser.fromJson constructor.");
    }
  }

  // ignore: unused_field
  __Map<__Type, __Object? Function(__Never)> _fns = {};

  __Map<__String, dynamic> toJsonCustom(
      [__Map<__Type, __Object? Function(__Never)>? fns]) {
    _fns = fns ?? {};
    return toJson();
  }

  __Map<__String, dynamic> toJson() {
    final __Map<__String, dynamic> data = _$ZikZakUserToJson(
      this,
    );
    // Adding custom key-value pair
    data['_className_'] = 'ZikZakUser';

    return data;
  }
}

extension $ZikZakUserchangeToE on $ZikZakUser {
  ZikZakUser changeToZikZakUser({
    String Function()? type,
    int Function()? id,
  }) {
    return ZikZakUser._(
      type: type == null ? this.type as String : type() as String,
      id: id == null ? this.id as int : id() as int,
    ) as ZikZakUser;
  }
}

enum ZikZakUser$ { type, id }
```

