### PR TITLE
feat: update to source_gen 2

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,5 +17,5 @@ dev_dependencies:
     path: ../morphy
   build_runner: ^2.4.6
   test: ^1.24.8
-  json_serializable: ^6.3.2
+  json_serializable: ^6.9.0
 

--- a/morphy/pubspec.yaml
+++ b/morphy/pubspec.yaml
@@ -12,9 +12,9 @@ environment:
 
 dependencies:
   morphy_annotation: ^1.1.0
-  analyzer: '>=6.0.0 <=7.0.0'
+  analyzer: '>=6.9.0 <8.0.0'
   build: ^2.1.0
-  source_gen: ^1.1.1
+  source_gen: ^2.0.0
   dartx: ^1.2.0
   quiver: ^3.2.1
 


### PR DESCRIPTION
## Summary
- update `source_gen` to ^2.0.0 with analyzer >=6.9.0 <8.0.0
- replace internal `source_gen` helper with local `normalizeGeneratorOutput`
- bump example's `json_serializable` to ^6.9.0

## Testing
- `dart pub get` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32a6ab0a4832fafbacb8ddcff1d94