### PR TITLE
Use local morphy_annotation package for builds

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -303,14 +303,14 @@ packages:
       path: "../morphy"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.3.0"
   morphy_annotation:
     dependency: "direct overridden"
     description:
       path: "../morphy_annotation"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.3.0"
   node_preamble:
     dependency: transitive
     description:

--- a/morphy/pubspec.lock
+++ b/morphy/pubspec.lock
@@ -303,7 +303,7 @@ packages:
       path: "../morphy_annotation"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.3.0"
   node_preamble:
     dependency: transitive
     description:

--- a/morphy/pubspec.yaml
+++ b/morphy/pubspec.yaml
@@ -6,9 +6,9 @@ homepage: https://github.com/atreeon/morphy
 environment:
   sdk: ">=3.1.3 <4.0.0"
 
-#dependency_overrides:
-#  morphy_annotation:
-#    path: ../morphy_annotation
+dependency_overrides:
+  morphy_annotation:
+    path: ../morphy_annotation
 
 dependencies:
   morphy_annotation: ^1.1.0


### PR DESCRIPTION
## Summary
- use local morphy_annotation via dependency overrides to avoid pulling incompatible hosted versions
- sync lock files with local morphy and morphy_annotation versions

## Testing
- `dart --version` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32d264dec832f9bd4d5a8fe311841