### PR TITLE
chore: update morphy for source_gen 2

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,6 +17,6 @@ dev_dependencies:
     path: ../morphy
   build_runner: ^2.4.6
   test: ^1.24.8
-  json_serializable: ^6.3.2
+  json_serializable: ^7.0.0
   json_annotation: ^4.9.0
 

--- a/morphy/CHANGELOG.md
+++ b/morphy/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.2
+- update dependencies to source_gen 2.x and analyzer >=6.9.0 <8.0.0
+
 ## 1.4.1
 - fixed bug with String2
 

--- a/morphy/pubspec.yaml
+++ b/morphy/pubspec.yaml
@@ -1,6 +1,6 @@
 name: morphy
 description: Provides a clean class definition with extra functionality including; copy with, json serializable, tostring, equals that supports inheritance and polymorphism
-version: 1.4.1
+version: 1.4.2
 homepage: https://github.com/atreeon/morphy
 
 environment:
@@ -17,9 +17,9 @@ dependencies:
 #      ref: toString2
 #      path: morphy_annotation
   morphy_annotation: ^1.4.1
-  analyzer: '>=6.0.0 <=7.0.0'
+  analyzer: '>=6.9.0 <8.0.0'
   build: ^2.1.0
-  source_gen: ^1.1.1
+  source_gen: ^2.0.0
   dartx: ^1.2.0
   quiver: ^3.2.1
 


### PR DESCRIPTION
## Summary
- support `source_gen` 2.x and newer analyzer in `morphy`
- bump example to `json_serializable` 7

## Testing
- `dart pub get` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3302641cc832f943464f06deb24a4