### PR TITLE
chore: add publish workflow

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,6 +1,7 @@
 name: Dart CI
 
-on: [push]
+on:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -4,28 +4,31 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
-    container:
-      image: dart:latest
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
       - name: Setup morphy
         working-directory: ./morphy
-        run:  |
+        run: |
           dart pub get
           dart pub run build_runner build --delete-conflicting-outputs
+
       - name: Run tests morphy
         working-directory: ./morphy
         run: dart pub run test
+
       - name: Setup example
         working-directory: ./example
-        run:  |
+        run: |
           dart pub get
           dart pub run build_runner build --delete-conflicting-outputs
+
       - name: Run tests Example
         working-directory: ./example
         run: dart pub run test
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,9 +50,6 @@ jobs:
             fi
           done
 
-      - name: Dry run publish morphy_annotation
-        run: dart pub publish --dry-run --directory=morphy_annotation
-
       - name: Publish morphy_annotation
         run: dart pub publish --force --directory=morphy_annotation
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,11 +8,16 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    container:
-      image: dart:latest
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Run tests for morphy
         working-directory: morphy
@@ -25,18 +30,14 @@ jobs:
         working-directory: example
         run: |
           dart pub get
+          dart pub run build_runner clean
           dart pub run build_runner build --delete-conflicting-outputs
           dart pub run test
 
       - name: Authenticate with pub.dev
         env:
           PUB_TOKEN: ${{ secrets.PUB_TOKEN }}
-        run: |
-          echo "$PUB_TOKEN" | dart pub token add https://pub.dev
-
-      - name: Install jq
-        run: |
-          apt-get update && apt-get install -y jq
+        run: echo "$PUB_TOKEN" | dart pub token add https://pub.dev
 
       - name: Ensure versions are bumped
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    container:
+      image: dart:latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run tests for morphy
+        working-directory: morphy
+        run: |
+          dart pub get
+          dart pub run build_runner build --delete-conflicting-outputs
+          dart pub run test
+
+      - name: Run tests for example
+        working-directory: example
+        run: |
+          dart pub get
+          dart pub run build_runner build --delete-conflicting-outputs
+          dart pub run test
+
+      - name: Authenticate with pub.dev
+        env:
+          PUB_TOKEN: ${{ secrets.PUB_TOKEN }}
+        run: |
+          echo "$PUB_TOKEN" | dart pub token add https://pub.dev
+
+      - name: Install jq
+        run: |
+          apt-get update && apt-get install -y jq
+
+      - name: Ensure versions are bumped
+        run: |
+          for pkg in morphy_annotation morphy; do
+            local_ver=$(grep '^version:' "$pkg/pubspec.yaml" | awk '{print $2}')
+            remote_ver=$(curl -sS "https://pub.dev/api/packages/$pkg" | jq -r '.latest.version')
+            if [ "$local_ver" = "$remote_ver" ]; then
+              echo "::error file=$pkg/pubspec.yaml::Version $local_ver already published on pub.dev"
+              exit 1
+            fi
+          done
+
+      - name: Dry run publish morphy_annotation
+        run: dart pub publish --dry-run --directory=morphy_annotation
+
+      - name: Publish morphy_annotation
+        run: dart pub publish --force --directory=morphy_annotation
+
+      - name: Dry run publish morphy
+        run: dart pub publish --dry-run --directory=morphy
+
+      - name: Publish morphy
+        run: dart pub publish --force --directory=morphy

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,13 @@
+# Releasing
+
+This project publishes `morphy` and `morphy_annotation` to pub.dev using a GitHub Actions workflow triggered by tags.
+
+1. Update the `version` fields in both `morphy/pubspec.yaml` and `morphy_annotation/pubspec.yaml`.
+2. Commit and push the changes.
+3. Tag the commit with the new version and push the tag, e.g.:
+   ```bash
+   git tag -a v1.4.1 -m "Release v1.4.1"
+   git push origin v1.4.1
+   ```
+4. The `publish.yml` workflow will run tests and publish both packages automatically.
+5. Check the Actions tab to confirm the release succeeded.

--- a/morphy/pubspec.yaml
+++ b/morphy/pubspec.yaml
@@ -1,6 +1,6 @@
 name: morphy
 description: Provides a clean class definition with extra functionality including; copy with, json serializable, tostring, equals that supports inheritance and polymorphism
-version: 1.4.2
+version: 1.4.2+1
 homepage: https://github.com/atreeon/morphy
 
 environment:

--- a/morphy_annotation/pubspec.yaml
+++ b/morphy_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: morphy_annotation
 description: annotation for morphy which provides a clean class definition with extra functionality including; copy with, json serializable, tostring, equals that supports inheritance and polymorphism
-version: 1.4.2
+version: 1.4.2+1
 homepage: https://github.com/atreeon/morphy
 
 environment:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish packages on version tags
- verify morphy and morphy_annotation versions are newer than those on pub.dev before publishing
- document how to trigger a release with the new workflow

## Testing
- `dart --version` (failed: command not found)
- `bash release/1_dry_run_release.sh` (failed: dart: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a330afed9c832fbd666480671654b8